### PR TITLE
Additional conformance testing

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -36,6 +36,9 @@ SequenceResult.auto_upgrade!
 TestResult.auto_migrate!
 TestResult.auto_upgrade!
 
+RequestResponse.auto_migrate!
+RequestResponse.auto_upgrade!
+
 enable :sessions
 set :session_secret, SecureRandom.uuid
 
@@ -78,27 +81,41 @@ end
 get '/instance/:id/conformance_sequence/?' do
   @instance = TestingInstance.get(params[:id])
   client = FHIR::Client.new(@instance.url)
+  conformance = client.conformance_statement
 
   # test that conformance is present and is DSTU2
-  if client.conformance_statement.nil?
+  if conformance.nil?
     conformance_present_result = TestResult.new(id: SecureRandom.uuid, name: 'Conformance Present', result: 'fail')
     conformance_dstu2_result = TestResult.new(id: SecureRandom.uuid, name: 'Conformance DSTU2', result: 'fail')
   else
     conformance_present_result = TestResult.new(id: SecureRandom.uuid, name: 'Conformance Present', result: 'pass')
-    if client.conformance_statement.is_a?(FHIR::DSTU2::Conformance)
+    if conformance.is_a?(FHIR::DSTU2::Conformance)
       conformance_dstu2_result = TestResult.new(id: SecureRandom.uuid, name: 'Conformance DSTU2', result: 'pass')
     else
       conformance_dstu2_result = TestResult.new(id: SecureRandom.uuid, name: 'Conformance DSTU2', result: 'fail')
     end
   end
+  conformance_present_result.save
+  conformance_dstu2_result.save
+
+  reply = client.reply
+  conformance_request_response = RequestResponse.new(id: SecureRandom.uuid, request_method: reply.request[:method].to_s, request_url: reply.request[:url], request_headers: reply.request[:headers], request_body: reply.request[:body], response_code: reply.response[:code], response_headers: reply.response[:headers], response_body: reply.response[:body])
+
+  # store TestResult in RequestResponse
+  conformance_request_response.test_results.push(conformance_present_result)
+  conformance_request_response.test_results.push(conformance_dstu2_result)
+  conformance_request_response.save
 
   # store TestResult in SequenceResult
   conformance_sequence_result = SequenceResult.new(id: SecureRandom.uuid, name: "Conformance", result: 'fail', passed_count: 0, failed_count: 2)
   conformance_sequence_result.test_results.push(conformance_present_result)
   conformance_sequence_result.test_results.push(conformance_dstu2_result)
+  conformance_sequence_result.save
 
   # store SequenceResult in TestingInstance
   @instance.sequence_results.push(conformance_sequence_result)
+  @instance.save
+  binding.pry
 end
 
 get '/instance/:id/redirect/:key/' do

--- a/app.rb
+++ b/app.rb
@@ -115,7 +115,6 @@ get '/instance/:id/conformance_sequence/?' do
   # store SequenceResult in TestingInstance
   @instance.sequence_results.push(conformance_sequence_result)
   @instance.save
-  binding.pry
 end
 
 get '/instance/:id/redirect/:key/' do

--- a/models/RequestResponse.rb
+++ b/models/RequestResponse.rb
@@ -1,0 +1,13 @@
+class RequestResponse
+  include DataMapper::Resource
+  property :id, String, key: true
+  property :request_method, String
+  property :request_url, String
+  property :request_headers, String
+  property :request_body, String
+  property :response_code, Integer
+  property :response_headers, String
+  property :response_body, String
+
+  has n, :test_results
+end

--- a/models/TestResult.rb
+++ b/models/TestResult.rb
@@ -4,5 +4,6 @@ class TestResult
   property :name, String
   property :result, String #pass fail
 
+  belongs_to :request_response
   belongs_to :sequence_result
 end

--- a/models/TestingInstance.rb
+++ b/models/TestingInstance.rb
@@ -3,10 +3,11 @@ class TestingInstance
   property :id, String, key: true
   property :url, String
   property :name, String
+  property :oauth_endpoint, String
+  property :fhir_format, String
   property :redirect_key, String
   property :launch_key, String
   property :created_at, DateTime
 
   has n, :sequence_results
 end
-


### PR DESCRIPTION
This PR implements a RequestResponse resource to store HTTP information for tests. Resources still need to be saved in the database. Further conformance tests need to be implemented. 