### PR TITLE
Change DataMapper id properties to String

### DIFF
--- a/models/SequenceResult.rb
+++ b/models/SequenceResult.rb
@@ -1,6 +1,6 @@
 class SequenceResult
   include DataMapper::Resource
-  property :id, Serial
+  property :id, String, key: true
   property :name, String
   property :result, String #pass fail
   property :passed_count, Integer

--- a/models/TestResult.rb
+++ b/models/TestResult.rb
@@ -1,6 +1,6 @@
 class TestResult
   include DataMapper::Resource
-  property :id, Serial
+  property :id, String, key: true
   property :name, String
   property :result, String #pass fail
 


### PR DESCRIPTION
DataMapper would not properly store TestResult or SequenceResult when trying to save. To fix this, the :id property simply needed to be changed to String, as in the other models.