### PR TITLE
Reworking a few details on this branch.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -81,7 +81,7 @@ post '/instance/?' do
   redirect "/instance/#{id}/"
 end
 
-get '/instance/:id/sequence/:sequence_id/?' do
+get '/instance/:id/Conformance/?' do
 
   instance = TestingInstance.get(params[:id])
   client = FHIR::Client.new(instance.url)
@@ -94,10 +94,10 @@ get '/instance/:id/sequence/:sequence_id/?' do
   instance.save!
 
   redirect "/instance/#{params[:id]}/?finished=#{params[:sequence_id]}"
-  
+
 end
 
-post '/instance/:id/conformance_sequence_skip/?' do
+post '/instance/:id/ConformanceSkip/?' do
 
   instance = TestingInstance.get(params[:id])
 
@@ -119,9 +119,9 @@ post '/instance/:id/dynamic_registration_skip/?' do
 
   instance = TestingInstance.get(params[:id])
 
-  conformance_sequence_result = SequenceResult.new(id: SecureRandom.uuid, name: "DynamicRegistration", result: "skip")
-  conformance_sequence_result.save
-  instance.sequence_results.push(conformance_sequence_result)
+  sequence_result = SequenceResult.new(id: SecureRandom.uuid, name: "DynamicRegistration", result: "skip")
+  sequence_result.save
+  instance.sequence_results.push(sequence_result)
 
   instance.client_id = params[:client_id]
   instance.dynamically_registered = false

--- a/lib/sequences/base.rb
+++ b/lib/sequences/base.rb
@@ -13,15 +13,20 @@ class SequenceBase
 
   @@test_index = 0
 
-  def initialize(instance, client)
+  def self.test_count
+    self.new(nil,nil).test_count
+  end
 
+  def test_count
+    self.methods.grep(/_test$/).length
+  end
+
+  def initialize(instance, client)
     @client = client
     @instance = instance
-
   end
 
   def start
-
     sequence_result = SequenceResult.new(id: SecureRandom.uuid, name: sequence_name, result: STATUS[:pass])
     methods = self.methods.grep(/_test$/).sort
     methods.each_with_index do |test_method, index|
@@ -30,12 +35,10 @@ class SequenceBase
       case result.result
       when STATUS[:pass]
         sequence_result.passed_count += 1
-
       when STATUS[:fail], STATUS[:error]
-        binding.pry
+        # binding.pry
         sequence_result.failed_count += 1
         sequence_result.result = result.result
-
       when STATUS[:wait]
         sequence_result.result = STATUS[:wait]
         sequence_result.wait_index = index
@@ -46,15 +49,18 @@ class SequenceBase
   end
 
   def sequence_name
-    self.class.name.split('::').last.split('Sequence').first
+    self.class.sequence_name
+  end
+
+  def self.sequence_name
+    self.name.split('::').last.split('Sequence').first
   end
 
   def self.description(description)
-    define_method 'description', -> () {description}
+    define_method 'display', -> () {description}
   end
 
   def self.test(name, url = nil, description = nil, &block)
-
     @@test_index += 1
 
     test_method = "#{@@test_index.to_s.rjust(4,"0")} #{name} test".downcase.tr(' ', '_').to_sym
@@ -101,5 +107,3 @@ class SequenceBase
 
 
 end
-
-

--- a/lib/sequences/conformance_sequence.rb
+++ b/lib/sequences/conformance_sequence.rb
@@ -11,8 +11,10 @@ class ConformanceSequence < SequenceBase
     assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
   end
 
-  test 'Conformance states proper json support' do
-    assert @conformance.format.include?('application/json+fhir'), 'Conformance statement does not state support for applciation/json+fhir.'
+  test 'Conformance states proper JSON or XML support' do
+    json = @conformance.format.include?(FHIR::Formats::ResourceFormat::RESOURCE_JSON_DSTU2)
+    xml = @conformance.format.include?(FHIR::Formats::ResourceFormat::RESOURCE_XML_DSTU2)
+    assert (json || xml), "Conformance statement does not state support for either #{FHIR::Formats::ResourceFormat::RESOURCE_JSON_DSTU2} or #{FHIR::Formats::ResourceFormat::RESOURCE_XML_DSTU2}."
   end
 
   test 'Conformance lists valid OAuth 2.0 endpoints' do
@@ -22,8 +24,7 @@ class ConformanceSequence < SequenceBase
     token_url = oauth_metadata[:token_url]
     assert (authorize_url =~ /\A#{URI::regexp(['http', 'https'])}\z/) == 0, "Invalid authorize url: '#{authorize_url}'"
     assert (token_url =~ /\A#{URI::regexp(['http', 'https'])}\z/) == 0, "Invalid token url: '#{token_url}'"
-    
+
     @instance.update(oauth_authorize_endpoint: authorize_url, oauth_token_endpoint: token_url)
   end
 end
-

--- a/models/SequenceResult.rb
+++ b/models/SequenceResult.rb
@@ -6,7 +6,7 @@ class SequenceResult
   property :passed_count, Integer, default: 0
   property :failed_count, Integer, default: 0
   property :wait_index, Integer, default: 0
-  property :warning_count, Integer
+  property :warning_count, Integer, default: 0
   property :created_at, DateTime, default: proc { DateTime.now }
 
   has n, :test_results

--- a/views/details.erb
+++ b/views/details.erb
@@ -107,61 +107,14 @@
 
     <div class="row scorecard-title">
       <div class="col-sm-9">
-        Test Sequences <span class="scorecard-title-details">(0 of 9 sequences successfully demonstrated)</span>
+        Test Sequences <span class="scorecard-title-details">(<%= @sequence_results.values.map(&:result).count("pass") %> of <%= SequenceBase.subclasses.count %> sequences successfully demonstrated)</span>
       </div>
       <div class="col-sm-3 text-right">
         <span class="oi oi-print" title="Print" aria-hidden="true"></span>
       </div>
     </div>
     <div class="scorecard-table">
-      <div class="scorecard-row">
-        <% case @sequence_results['Conformance'].try(:result)
-          when nil %>
-            <div class="scorecard-score scorecard-score-pending">
-              <span class="oi oi-ellipses" title="Pending" aria-hidden="true"></span>
-            </div>
-        <% when 'pass' %>
-            <div class="scorecard-score scorecard-score-pass">
-              <span class="oi oi-check" title="Pass" aria-hidden="true"></span>
-            </div>
-        <% when 'fail' %>
-            <div class="scorecard-score scorecard-score-fail">
-              <span class="oi oi-x" title="Fail" aria-hidden="true"></span>
-            </div>
-        <% when 'skip' %>
-            <div class="scorecard-score scorecard-score-skip">
-              <span class="oi oi-warning" title="Skip" aria-hidden="true"></span>
-            </div>
-        <% end %>
-        <div class="scorecard-rubric">
-          <div class="scorecard-name">
-            Capability Statement
-          </div>
-          <div class="scorecard-out-of">
-            <% if @sequence_results['Conformance'].nil? %>
-              10 tests
-            <% elsif @sequence_results['Conformance'].result == 'skip'%>
-              Test skipped
-
-            <% else %>
-              <%= @sequence_results['Conformance'].passed_count %> Passed -
-              <%= @sequence_results['Conformance'].failed_count %> Failed -
-              (<%= @sequence_results['Conformance'].warning_count %> Warning(s))
-
-            <% end %>
-          </div>
-          <div class="scorecard-details">
-            The FHIR server properly exposes a capability statement with necessary information.
-          </div>
-        </div>
-        <div class="scorecard-action">
-          <a href="sequence/ConformanceSequence/" role="button" class="btn btn-primary"><%if @instance.oauth_token_endpoint.nil? %>Begin<% else %>Rerun<% end %></a>
-          <% if @sequence_results['Conformance'].nil? || @sequence_results['Conformance'].result == 'fail'%>
-            <button type="submit" class="btn btn-primary" data-toggle="modal" data-target="#conformanceSkipModal">Skip</button>
-          <% end %>
-        </div>
-      </div>
-
+        <%= erb(:sequence,{},{sequence_class: ConformanceSequence}) %>
       <div class="scorecard-row">
         <% case @sequence_results['DynamicRegistration'].try(:result)
           when nil %>
@@ -205,19 +158,33 @@
         </div>
       </div>
       <div class="scorecard-row">
-        <div class="scorecard-score" style="background-color: #fff; color: #666; border: 2px solid #666">
-          <span class="oi oi-ellipses" title="Pending" aria-hidden="true"></span>
-        </div>
+        <% case @sequence_results['Launch'].try(:result)
+          when nil %>
+            <div class="scorecard-score scorecard-score-pending">
+              <span class="oi oi-ellipses" title="Pending" aria-hidden="true"></span>
+            </div>
+        <% when 'pass' %>
+            <div class="scorecard-score scorecard-score-pass">
+              <span class="oi oi-check" title="Pass" aria-hidden="true"></span>
+            </div>
+        <% when 'fail' %>
+            <div class="scorecard-score scorecard-score-fail">
+              <span class="oi oi-x" title="Fail" aria-hidden="true"></span>
+            </div>
+        <% when 'skip' %>
+            <div class="scorecard-score scorecard-score-skip">
+              <span class="oi oi-warning" title="Skip" aria-hidden="true"></span>
+            </div>
+        <% end %>
         <div class="scorecard-rubric">
           <div class="scorecard-name">
             Demonstrate at least one Launch Sequence
-
           </div>
           <div class="scorecard-out-of">
-            0 of 4 passed
+            <%= @sequence_results['Launch'].try(:result).try(:passed_count) %> of 4 passed
           </div>
           <div class="scorecard-out-of">
-            0 warnings
+            <%= @sequence_results['Launch'].try(:result).try(:warning_count) %> warnings
           </div>
           <div class="scorecard-details">
             The server supports at least one of the following required launch sequences.
@@ -253,9 +220,24 @@
       </div>
 
       <div class="scorecard-row" style="padding-left: 50px">
-        <div class="scorecard-score" style="background-color: #fff; color: #666; border: 2px solid #666">
-          <span class="oi oi-ellipses" title="Pending" aria-hidden="true"></span>
-        </div>
+        <% case @sequence_results['Launch'].try(:result)
+          when nil %>
+            <div class="scorecard-score scorecard-score-pending">
+              <span class="oi oi-ellipses" title="Pending" aria-hidden="true"></span>
+            </div>
+        <% when 'pass' %>
+            <div class="scorecard-score scorecard-score-pass">
+              <span class="oi oi-check" title="Pass" aria-hidden="true"></span>
+            </div>
+        <% when 'fail' %>
+            <div class="scorecard-score scorecard-score-fail">
+              <span class="oi oi-x" title="Fail" aria-hidden="true"></span>
+            </div>
+        <% when 'skip' %>
+            <div class="scorecard-score scorecard-score-skip">
+              <span class="oi oi-warning" title="Skip" aria-hidden="true"></span>
+            </div>
+        <% end %>
         <div class="scorecard-rubric">
           <div class="scorecard-name">
             Provider Standalone Launch
@@ -411,7 +393,7 @@
 </div>
 
 <!-- Modals -->
-<div class="modal fade" id="conformanceSkipModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="ConformanceSequenceSkipModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -420,16 +402,11 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <form method="POST" action="conformance_sequence_skip">
+      <form method="POST" action="ConformanceSkip">
         <div class="modal-body">
           <p>
-            Description.
-            Description.
-            Description.
-            Description.
-            Description.
-            Description.
-            Description.
+            If you want to skip the Conformance sequence, then you are required
+            to manually supply authorization and token endpoints.
           </p>
             <div class="form-group">
               <label for="conformanceAuthorizeEndpoint">OAuth 2.0 Authorize Endpoint</label>
@@ -497,7 +474,7 @@
           </p>
           <div class="form-group">
             <label for="providerStandaloneLaunchScopes">Scopes</label>
-            <input type="text" class="form-control" name="scopes" id="providerStandaloneLaunchScopes">
+            <input type="text" class="form-control" name="scopes" id="providerStandaloneLaunchScopes" value="launch/patient patient/*.read openid profile">
           </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/views/sequence.erb
+++ b/views/sequence.erb
@@ -1,0 +1,46 @@
+<div class="scorecard-row">
+  <% case @sequence_results[sequence_class.sequence_name].try(:result)
+    when nil %>
+      <div class="scorecard-score scorecard-score-pending">
+        <span class="oi oi-ellipses" title="Pending" aria-hidden="true"></span>
+      </div>
+  <% when 'pass' %>
+      <div class="scorecard-score scorecard-score-pass">
+        <span class="oi oi-check" title="Pass" aria-hidden="true"></span>
+      </div>
+  <% when 'fail' %>
+      <div class="scorecard-score scorecard-score-fail">
+        <span class="oi oi-x" title="Fail" aria-hidden="true"></span>
+      </div>
+  <% when 'skip' %>
+      <div class="scorecard-score scorecard-score-skip">
+        <span class="oi oi-warning" title="Skip" aria-hidden="true"></span>
+      </div>
+  <% end %>
+  <div class="scorecard-rubric">
+    <div class="scorecard-name">
+      <%= sequence_class.sequence_name %>
+    </div>
+    <div class="scorecard-out-of">
+      <% if @sequence_results[sequence_class.sequence_name].nil? %>
+        <%= sequence_class.test_count %> tests
+      <% elsif @sequence_results[sequence_class.sequence_name].result == 'skip' %>
+        Test skipped
+      <% else %>
+        <%= @sequence_results[sequence_class.sequence_name].passed_count %> Passed -
+        <%= @sequence_results[sequence_class.sequence_name].failed_count %> Failed -
+        <%= @sequence_results[sequence_class.sequence_name].warning_count %> Warning(s)
+      <% end %>
+    </div>
+    <div class="scorecard-details">
+      <%= sequence_class.new(nil,nil).display %>
+    </div>
+  </div>
+  <div class="scorecard-action">
+    <a href="<%= sequence_class.sequence_name %>/" role="button" class="btn btn-primary">
+    <% unless @sequence_results[sequence_class.sequence_name] %>Begin<% else %>Rerun<% end %></a>
+    <% if @sequence_results[sequence_class.sequence_name].nil? || @sequence_results[sequence_class.sequence_name].result == 'fail'%>
+      <button type="submit" class="btn btn-primary" data-toggle="modal" data-target="#<%= sequence_class.sequence_name %>SkipModal">Skip</button>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
Posting some of the changes I made today while examining the code. You can merge these or toss them aside.

This PR adds another ERB template called `sequence.erb` so we don't need all that copying and pasting in `details.erb`. Needs work, but the idea is that you just render a sequence with a single template, and the generated button defaults have sensible urls based on the class name (e.g. `/instance/:id/Conformance/?` for `ConformanceSequence`).

Also, stubbed out default values for `scopes` in the modal for provider standalone launch.

My next steps
- Replace the current `DynamicRegistrationSequence` using this model
- Do a little work to add nesting, so the individual launch sequences roll up to the "Demonstrate at Least One Launch Sequence".
