### PR TITLE
Implement client bearer token for OAuth

### DIFF
--- a/lib/sequences/argonaut_sequence.rb
+++ b/lib/sequences/argonaut_sequence.rb
@@ -2,9 +2,12 @@ class ArgonautSequence < SequenceBase
 
   description 'The FHIR server properly follows the Argonaut Data Query Implementation Guide.'
 
+  # --------------------------------------------------
+  # StructureDefinition-argo-patient
+  # --------------------------------------------------
+
   test 'Has Patient resource',
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html',
-          'Exact Language' do
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html' do
 
     patient_read_response = @client.read(FHIR::DSTU2::Patient, @instance.patient_id)
     assert_response_ok patient_read_response
@@ -14,27 +17,45 @@ class ArgonautSequence < SequenceBase
     assert @patient.is_a?(FHIR::DSTU2::Patient), 'Expected resource to be valid DSTU2 Patient'
   end
 
-  test 'Patient has identifier',
+  test 'Patient has valid identifier(s)',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html',
           'Each Patient must have: 1. a patient identifier (e.g. MRN)' do
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
-    assert !@patient_details['id'].nil?, 'Expected Patient to have identifier'
+    assert !@patient_details['identifier'].nil?, 'Expected Patient to have Patient.identifier'
+    @patient_details['identifier'].each do |identifier|
+      assert !(identifier['system'].nil? || identifier['system'].to_s.strip.empty?), 'Expected each Patient.identifier to have Patient.identifier.system'
+      assert !(identifier['value'].nil? || identifier['value'].to_s.strip.empty?), 'Expected each Patient.identifier to have Patient.identifier.value'
+    end
   end
 
-  test 'Patient has name',
+  test 'Patient has valid name(s)',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html',
           'Each Patient must have: 2. a patient name' do
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
-    assert !@patient_details['name'].nil?, 'Expected Patient to have name'
+    assert !@patient_details['name'].nil?, 'Expected Patient to have Patient.name'
+    @patient_details['name'].each do |name|
+      assert !(name['family'].nil? || name['family'].to_s.strip.empty?), 'Expected each Patient.name to have Patient.name.family'
+      assert !(name['given'].nil? || name['given'].to_s.strip.empty?), 'Expected each Patient.name to have Patient.name.given'
+    end
   end
 
-  test 'Patient has gender',
+  test 'Patient has valid gender',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html',
           'Each Patient must have: 3. a patient gender' do
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
-    assert !@patient_details['gender'].nil?, 'Expected Patient to have gender'
+    assert !@patient_details['gender'].nil?, 'Expected Patient to have Patient.gender'
+    assert ['male', 'female', 'other', 'unknown'].include?(@patient_details['gender']), 'Expected Patient gender to be bound to AdministrativeGender ValueSet'
   end
+
+  test 'Patient has valid birth date',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html',
+          'If the data is present, Patient shall include: 1. a birth date' do
+
+    assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
+    assert !@patient_details['birthDate'].nil?, 'Expected Patient to have Patient.birthDate'
+  end
+
 end

--- a/lib/sequences/base.rb
+++ b/lib/sequences/base.rb
@@ -27,6 +27,7 @@ class SequenceBase
   def initialize(instance, client)
     @client = client
     @instance = instance
+    @client.set_bearer_token(@instance.token) unless (@client.nil? || @instance.nil? || @instance.token.nil?)
   end
 
   def start

--- a/models/TestingInstance.rb
+++ b/models/TestingInstance.rb
@@ -11,10 +11,12 @@ class TestingInstance
   property :oauth_authorize_endpoint, String
   property :oauth_token_endpoint, String
   property :fhir_format, String
-  property :client_id, String
 
   property :dynamically_registered, Boolean
   property :client_endpoint_key, String, default: proc { SecureRandomBase62.generate(32) }
+
+  property :token, String
+  property :patient_id, String
 
   property :created_at, DateTime, default: proc { DateTime.now }
 


### PR DESCRIPTION
Stores client bearer token so that Argonaut testing can be done after launch testing. Also adds some additional Argonaut testing.