### PR TITLE
Implement search test skeletons for supported searches

### DIFF
--- a/lib/sequences/argonaut_search_sequence.rb
+++ b/lib/sequences/argonaut_search_sequence.rb
@@ -6,7 +6,72 @@ class ArgonautSearchSequence < SequenceBase
   # Patient Search
   # --------------------------------------------------
 
-  test 'Patient search' do
+  test 'Patient search by name',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: name' do
+
+    throw "TODO"
+  end
+
+  test 'Patient search by family',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: family' do
+
+    throw "TODO"
+  end
+
+  test 'Patient search by given',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: given' do
+
+    throw "TODO"
+  end
+
+  test 'Patient search by identifier',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: identifier' do
+
+    throw "TODO"
+  end
+
+  test 'Patient search by gender',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: gender' do
+
+    throw "TODO"
+  end
+
+  test 'Patient search by birthdate',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: birthdate' do
+
+    throw "TODO"
+  end
+
+  test 'Patient search by name + gender',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: name + gender' do
+
+    throw "TODO"
+  end
+
+  test 'Patient search by name + birthdate',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: name + birthdate' do
+
+    throw "TODO"
+  end
+
+  test 'Patient search by family + gender',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: family + gender' do
+
+    throw "TODO"
+  end
+
+  test 'Patient search by given + gender',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: given + gender' do
 
     throw "TODO"
   end
@@ -15,7 +80,9 @@ class ArgonautSearchSequence < SequenceBase
   # AllergyIntolerance Search
   # --------------------------------------------------
 
-  test 'AllergyIntolerance search' do
+  test 'AllergyIntolerance search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
 
     throw "TODO"
   end
@@ -24,16 +91,58 @@ class ArgonautSearchSequence < SequenceBase
   # CarePlan Search
   # --------------------------------------------------
 
-  test 'CarePlan search' do
+  test 'CarePlan search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
 
     throw "TODO"
   end
 
-  # --------------------------------------------------
-  # CareTeam Search
-  # --------------------------------------------------
+  test 'CarePlan search by category',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: category' do
 
-  test 'CareTeam search' do
+    throw "TODO"
+  end
+
+  test 'CarePlan search by status',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: status' do
+
+    throw "TODO"
+  end
+
+  test 'CarePlan search by date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: date' do
+
+    throw "TODO"
+  end
+
+  test 'CarePlan search by patient + category',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category' do
+
+    throw "TODO"
+  end
+
+  test 'CarePlan search by patient + category + date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category + date' do
+
+    throw "TODO"
+  end
+
+  test 'CarePlan search by patient + category + status',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category + status' do
+
+    throw "TODO"
+  end
+
+  test 'CarePlan search by patient + category + status + date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category + status + date' do
 
     throw "TODO"
   end
@@ -42,7 +151,37 @@ class ArgonautSearchSequence < SequenceBase
   # Condition Search
   # --------------------------------------------------
 
-  test 'Condition search' do
+  test 'Condition search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
+
+    throw "TODO"
+  end
+
+  test 'Condition search by category',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: category' do
+
+    throw "TODO"
+  end
+
+  test 'Condition search by clinicalstatus',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: clinicalstatus' do
+
+    throw "TODO"
+  end
+
+  test 'Condition search by patient + clinicalstatus',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + clinicalstatus' do
+
+    throw "TODO"
+  end
+
+  test 'Condition search by patient + category',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category' do
 
     throw "TODO"
   end
@@ -51,7 +190,9 @@ class ArgonautSearchSequence < SequenceBase
   # Device Search
   # --------------------------------------------------
 
-  test 'Device search' do
+  test 'Device search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
 
     throw "TODO"
   end
@@ -60,7 +201,23 @@ class ArgonautSearchSequence < SequenceBase
   # Goal Search
   # --------------------------------------------------
 
-  test 'Goal search' do
+  test 'Goal search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
+
+    throw "TODO"
+  end
+
+  test 'Goal search by date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: date' do
+
+    throw "TODO"
+  end
+
+  test 'Goal search by patient + date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + date' do
 
     throw "TODO"
   end
@@ -69,7 +226,9 @@ class ArgonautSearchSequence < SequenceBase
   # Immunization Search
   # --------------------------------------------------
 
-  test 'Immunization search' do
+  test 'Immunization search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
 
     throw "TODO"
   end
@@ -78,7 +237,58 @@ class ArgonautSearchSequence < SequenceBase
   # DiagnosticReport Search
   # --------------------------------------------------
 
-  test 'DiagnosticReport search' do
+  test 'DiagnosticReport search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
+
+    throw "TODO"
+  end
+
+  test 'DiagnosticReport search by category',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: category' do
+
+    throw "TODO"
+  end
+
+  test 'DiagnosticReport search by code',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: code' do
+
+    throw "TODO"
+  end
+
+  test 'DiagnosticReport search by date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: date' do
+
+    throw "TODO"
+  end
+
+  test 'DiagnosticReport search by patient + category',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category' do
+
+    throw "TODO"
+  end
+
+  test 'DiagnosticReport search by patient + category + date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category + date' do
+
+    throw "TODO"
+  end
+
+  test 'DiagnosticReport search by patient + category + code',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category + code' do
+
+    throw "TODO"
+  end
+
+  test 'DiagnosticReport search by patient + category + code + date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category + code + date' do
 
     throw "TODO"
   end
@@ -87,16 +297,13 @@ class ArgonautSearchSequence < SequenceBase
   # Medication Search
   # --------------------------------------------------
 
-  test 'Medication search' do
-
-    throw "TODO"
-  end
-
   # --------------------------------------------------
   # MedicationStatement Search
   # --------------------------------------------------
 
-  test 'MedicationStatement search' do
+  test 'MedicationStatement search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
 
     throw "TODO"
   end
@@ -105,7 +312,9 @@ class ArgonautSearchSequence < SequenceBase
   # MedicationOrder Search
   # --------------------------------------------------
 
-  test 'MedicationOrder search' do
+  test 'MedicationOrder search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
 
     throw "TODO"
   end
@@ -114,7 +323,58 @@ class ArgonautSearchSequence < SequenceBase
   # Observation Search
   # --------------------------------------------------
 
-  test 'Observation search' do
+  test 'Observation search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
+
+    throw "TODO"
+  end
+
+  test 'Observation search by category',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: category' do
+
+    throw "TODO"
+  end
+
+  test 'Observation search by code',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: code' do
+
+    throw "TODO"
+  end
+
+  test 'Observation search by date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: date' do
+
+    throw "TODO"
+  end
+
+  test 'Observation search by patient + category',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category' do
+
+    throw "TODO"
+  end
+
+  test 'Observation search by patient + category + date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category + date' do
+
+    throw "TODO"
+  end
+
+  test 'Observation search by patient + category + code',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category + code' do
+
+    throw "TODO"
+  end
+
+  test 'Observation search by patient + category + code + date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + category + code + date' do
 
     throw "TODO"
   end
@@ -123,7 +383,23 @@ class ArgonautSearchSequence < SequenceBase
   # Procedure Search
   # --------------------------------------------------
 
-  test 'Procedure search' do
+  test 'Procedure search by patient',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient' do
+
+    throw "TODO"
+  end
+
+  test 'Procedure search by date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: date' do
+
+    throw "TODO"
+  end
+
+  test 'Procedure search by patient + date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'Supported Searches: patient + date' do
 
     throw "TODO"
   end


### PR DESCRIPTION
Implements Argonaut search test skeletons. As with the profile skeletons, we will need to review these tests in detail as we write them to make sure they are exactly what we need, but this is what is initially apparent from documentation.