### PR TITLE
Test redirect refactor

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -99,19 +99,6 @@ get '/instance/:id/:sequence/?' do
   redirect "/instance/#{params[:id]}/##{params[:sequence]}"
 end
 
-
-# get '/instance/:id/Conformance/?' do
-#   instance = TestingInstance.get(params[:id])
-#   client = FHIR::Client.new(instance.url)
-# 
-#   sequence = ConformanceSequence.new(instance, client)
-#   sequence_result = sequence.start
-#   instance.sequence_results.push(sequence_result)
-#   instance.save!
-# 
-#   redirect "/instance/#{params[:id]}/##{params[:sequence_id]}"
-# end
-
 post '/instance/:id/ConformanceSkip/?' do
   instance = TestingInstance.get(params[:id])
 

--- a/app.rb
+++ b/app.rb
@@ -29,7 +29,7 @@ end
 
 DataMapper.finalize
 
-[TestingInstance, SequenceResult, TestResult, RequestResponse, RequestResponseTestResult].each do |model|
+[TestingInstance, SequenceResult, TestResult, Warning, RequestResponse, RequestResponseTestResult].each do |model|
   # model.auto_migrate!
   model.auto_upgrade!
 end
@@ -68,12 +68,26 @@ get '/instance/:id/test_result/:test_result_id/?' do
   erb :test_result_details, layout: false
 end
 
-get '/instance/:id/:sequence/' do
+get '/instance/:id/sequence_result/:sequence_result_id/cancel' do
+
+  @sequence_result = SequenceResult.get(params[:sequence_result_id])
+  halt 404 if @sequence_result.testing_instance.id != params[:id]
+
+  @sequence_result.result = 'cancel'
+  @sequence_result.save!
+
+  redirect "/instance/#{params[:id]}/##{@sequence_result.name}"
+
+end
+
+
+get '/instance/:id/:sequence/?' do
   instance = TestingInstance.get(params[:id])
   client = FHIR::Client.new(instance.url)
   klass = SequenceBase.subclasses.find{|x| x.to_s.start_with?(params[:sequence])}
   if klass
     sequence = klass.new(instance, client)
+
     sequence_result = sequence.start
     instance.sequence_results.push(sequence_result)
     instance.save!
@@ -85,17 +99,18 @@ get '/instance/:id/:sequence/' do
   redirect "/instance/#{params[:id]}/##{params[:sequence]}"
 end
 
-get '/instance/:id/Conformance/?' do
-  instance = TestingInstance.get(params[:id])
-  client = FHIR::Client.new(instance.url)
 
-  sequence = ConformanceSequence.new(instance, client)
-  sequence_result = sequence.start
-  instance.sequence_results.push(sequence_result)
-  instance.save!
-
-  redirect "/instance/#{params[:id]}/##{params[:sequence_id]}"
-end
+# get '/instance/:id/Conformance/?' do
+#   instance = TestingInstance.get(params[:id])
+#   client = FHIR::Client.new(instance.url)
+# 
+#   sequence = ConformanceSequence.new(instance, client)
+#   sequence_result = sequence.start
+#   instance.sequence_results.push(sequence_result)
+#   instance.save!
+# 
+#   redirect "/instance/#{params[:id]}/##{params[:sequence_id]}"
+# end
 
 post '/instance/:id/ConformanceSkip/?' do
   instance = TestingInstance.get(params[:id])
@@ -177,27 +192,7 @@ end
 post '/instance/:id/PatientStandaloneLaunch/?' do
   @instance = TestingInstance.get(params[:id])
   @instance.update(scopes: params['scopes'])
-  @instance.update(launch_type: 'PatientStandaloneLaunch')
-
-  session[:client_id] = @instance.client_id
-  session[:fhir_url] = @instance.url
-  session[:authorize_url] = @instance.oauth_authorize_endpoint
-  session[:token_url] = @instance.oauth_token_endpoint
-  session[:state] = SecureRandom.uuid
-  oauth2_params = {
-    'response_type' => 'code',
-    'client_id' => @instance.client_id,
-    'redirect_uri' => request.base_url + '/instance/' + @instance.id + '/' + @instance.client_endpoint_key + '/redirect', # TODO don't hard code base URL
-    'scope' => @instance.scopes,
-    'state' => session[:state],
-    'aud' => @instance.url
-  }
-  oauth2_auth_query = "#{session[:authorize_url]}?"
-  oauth2_params.each do |key,value|
-    oauth2_auth_query += "#{key}=#{CGI.escape(value)}&"
-  end
-  puts "Launch Authz Query: #{oauth2_auth_query[0..-2]}"
-  redirect oauth2_auth_query[0..-2]
+  redirect "/instance/#{params[:id]}/PatientStandaloneLaunch/"
 end
 
 get '/instance/:id/:key/:endpoint/?' do
@@ -222,96 +217,4 @@ get '/instance/:id/:key/:endpoint/?' do
     redirect "/instance/#{params[:id]}/##{sequence_result.name}"
 
   end
-end
-
-get '/instance/:id/launch2/?' do
-  @instance = TestingInstance.get(params[:id])
-  @instance.update(launch_type: 'ProviderEHRLaunch', scopes: 'launch online_access openid patient/*.* profile')
-
-  if params && params['iss'] && params['launch']
-    session[:client_id] = @instance.client_id
-    # session[:fhir_url] = params['iss']
-    session[:authorize_url] = @instance.oauth_authorize_endpoint
-    session[:token_url] = @instance.oauth_token_endpoint
-    session[:state] = SecureRandom.uuid
-    oauth2_params = {
-      'response_type' => 'code',
-      'client_id' => @instance.client_id,
-      'redirect_uri' => request.base_url + '/instance/' + @instance.id + '/redirect2', # TODO don't hard code base URL
-      'scope' => @instance.scopes,
-      'launch' => params['launch'],
-      'state' => session[:state],
-      'aud' => params['iss']
-    }
-    oauth2_auth_query = "#{session[:authorize_url]}?"
-    oauth2_params.each do |key,value|
-      oauth2_auth_query += "#{key}=#{CGI.escape(value)}&"
-    end
-    puts "Launch Authz Query: #{oauth2_auth_query[0..-2]}"
-    redirect oauth2_auth_query[0..-2]
-  else
-    redirect "/instance/#{params[:id]}/#{params[:key]}/redirect?error=EHR Launch requires iss and launch parameters."
-  end
-end
-
-get '/instance/:id/:key/redirect/?' do
-  @instance = TestingInstance.get(params[:id])
-
-  # test that launch is successful
-  if params['error']
-    launch_success_result = TestResult.new(id: SecureRandom.uuid, name: @instance.launch_type, result: 'fail', message: params['error'])
-  else
-    launch_success_result = TestResult.new(id: SecureRandom.uuid, name: @instance.launch_type, result: 'pass')
-    oauth2_params = {
-      'grant_type' => 'authorization_code',
-      'code' => params['code'],
-      'redirect_uri' => 'http://localhost:4567/instance/' + @instance.id + '/' + @instance.client_endpoint_key + '/redirect', # TODO don't hard code base URL
-      'client_id' => @instance.client_id
-    }
-    token_response = RestClient.post(@instance.oauth_token_endpoint, oauth2_params)
-    token_response = JSON.parse(token_response.body)
-    token = token_response['access_token']
-    patient_id = token_response['patient']
-    scopes = token_response['scope']
-    @instance.update(token: token, patient_id: patient_id, scopes: scopes)
-  end
-
-  # launch_request_response = RequestResponse.new(id: SecureRandom.uuid) # TODO fill out RequestResponse
-  # launch_request_response.test_results.push(launch_success_result)
-
-  # store TestResult in SequenceResult
-  launch_sequence_result = SequenceResult.new(id: SecureRandom.uuid, name: @instance.launch_type)
-  launch_sequence_result.test_results.push(launch_success_result)
-
-  passed_count = 0
-  failed_count = 0
-  warning_count = 0
-  launch_sequence_result.test_results.each do |test_result|
-    if test_result.result == 'pass'
-      passed_count += 1
-    elsif test_result.result == 'fail'
-      failed_count += 1
-    end
-
-    unless test_result.warning.nil?
-      warning_count += 1
-    end
-  end
-  result = (failed_count.zero?) ? 'pass' : 'fail'
-  launch_sequence_result.passed_count = passed_count
-  launch_sequence_result.failed_count = failed_count
-  launch_sequence_result.warning_count = warning_count
-  launch_sequence_result.result = result
-
-  # store SequenceResult in TestingInstance
-  @instance.sequence_results.push(launch_sequence_result)
-
-  @instance.save
-
-  sequence = LaunchSequence.new(@instance, nil)
-  sequence_result = sequence.start
-  @instance.sequence_results.push(sequence_result)
-  @instance.save
-
-  redirect "/instance/#{params[:id]}/##{@instance.launch_type}"
 end

--- a/lib/sequence_base.rb
+++ b/lib/sequence_base.rb
@@ -4,13 +4,13 @@ class SequenceBase
   include Assertions
 
   STATUS = {
+    running: 'running',
     pass: 'pass',
     fail: 'fail',
     error: 'error',
     todo: 'todo',
+    wait: 'wait'
   }
-
-  TODO = :todo
 
   @@test_index = 0
   @@modal_before_run = []
@@ -26,17 +26,35 @@ class SequenceBase
     self.methods.grep(/_test$/).length
   end
 
-  def initialize(instance, client)
+  def initialize(instance, client, sequence_result = nil)
     @client = client
     @instance = instance
     @client.set_bearer_token(@instance.token) unless (@client.nil? || @instance.nil? || @instance.token.nil?)
     @client.monitor_requests unless @client.nil?
+    @sequence_result = sequence_result
+  end
+
+  def resume(params)
+
+    @params = params
+    @sequence_result.test_results.last.result = STATUS[:pass]
+    @sequence_result.wait_at_endpoint = nil
+    @sequence_result.redirect_to_url = nil
+
+    start
   end
 
   def start
-    sequence_result = SequenceResult.new(id: SecureRandom.uuid, name: sequence_name, result: STATUS[:pass])
+    if @sequence_result.nil?
+      @sequence_result = SequenceResult.new(id: SecureRandom.uuid, name: sequence_name, result: STATUS[:pass])
+    end
+
+    start_at = @sequence_result.test_results.length
+    puts "STARTING AT #{start_at}"
+
     methods = self.methods.grep(/_test$/).sort
     methods.each_with_index do |test_method, index|
+      next if index < start_at
       @client.requests = [] unless @client.nil?
       result = self.method(test_method).call()
 
@@ -54,22 +72,29 @@ class SequenceBase
         end
       end
 
-      sequence_result.test_results << result
+      @sequence_result.test_results << result
 
       case result.result
       when STATUS[:pass]
-        sequence_result.passed_count += 1
+        @sequence_result.passed_count += 1
       when STATUS[:todo]
-        sequence_result.todo_count += 1
+        @sequence_result.todo_count += 1
       when STATUS[:fail]
-        sequence_result.failed_count += 1
-        sequence_result.result = result.result unless sequence_result.result == STATUS[:error]
+        @sequence_result.failed_count += 1
+        @sequence_result.result = result.result unless @sequence_result.result == STATUS[:error]
       when STATUS[:error]
-        sequence_result.error_count += 1
-        sequence_result.result = result.result
+        @sequence_result.error_count += 1
+        @sequence_result.result = result.result
+      when STATUS[:wait]
+        @sequence_result.result = result.result
+        @sequence_result.redirect_to_url = result.redirect_to_url
+        @sequence_result.wait_at_endpoint = result.wait_at_endpoint
       end
+
+      break if result.result == STATUS[:wait]
+
     end
-    sequence_result
+    @sequence_result
   end
 
   def sequence_name
@@ -134,23 +159,34 @@ class SequenceBase
     contents = block
     wrapped = -> () do
       @warnings, @links, @requires, @validates = [],[],[],[]
-      result = ""
       result = TestResult.new(id: SecureRandom.uuid, name: name, result: STATUS[:pass], url: url, description: description)
       begin
-        t = instance_eval &block
-
-        result.result = STATUS[:todo] if t == TODO
+        instance_eval &block
 
         # result.update(t.status, t.message, t.data) if !t.nil? && t.is_a?(Crucible::Tests::TestResult)
       rescue AssertionException => e
         result.result = STATUS[:fail]
         result.message = e.message
-      rescue SkipException => e
-        # result.update(STATUS[:skip], "Skipped: #{e.message}", '')
+
+      rescue TodoException => e
+        result.result = STATUS[:todo]
+        result.message = e.message
+
       rescue ClientException => e
         result.result = STATUS[:fail]
         result.message = e.message
-        # result.update(STATUS[:fail], e.message, '')
+
+      rescue WaitException => e
+        result.result = STATUS[:wait]
+        result.wait_at_endpoint = e.endpoint
+
+      rescue RedirectException => e
+        result.result = STATUS[:wait]
+        result.wait_at_endpoint = e.endpoint
+        result.redirect_to_url = e.url
+
+      # rescue SkipException => e
+      #   result.update(STATUS[:skip], "Skipped: #{e.message}", '')
       rescue => e
         result.result = STATUS[:error]
         result.message = "Fatal Error: #{e.message}"
@@ -169,4 +205,17 @@ class SequenceBase
 
     define_method test_method, wrapped
   end
+
+  def todo(message = "")
+    raise TodoException.new message
+  end
+
+  def wait_at_endpoint(endpoint)
+    raise WaitException.new endpoint
+  end
+
+  def redirect(url, endpoint)
+    raise RedirectException.new url, endpoint
+  end
 end
+

--- a/lib/sequence_base.rb
+++ b/lib/sequence_base.rb
@@ -4,7 +4,6 @@ class SequenceBase
   include Assertions
 
   STATUS = {
-    running: 'running',
     pass: 'pass',
     fail: 'fail',
     error: 'error',

--- a/lib/sequences/01_conformance_sequence.rb
+++ b/lib/sequences/01_conformance_sequence.rb
@@ -37,4 +37,5 @@ class ConformanceSequence < SequenceBase
 
     @instance.update(oauth_register_endpoint: registration_url)
   end
+
 end

--- a/lib/sequences/03a_patient_standalone_launch_sequence.rb
+++ b/lib/sequences/03a_patient_standalone_launch_sequence.rb
@@ -8,6 +8,55 @@ class PatientStandaloneLaunchSequence < SequenceBase
     !@instance.client_id.nil?
   end
 
-  test 'Patient Standalone Launch' do
+  test 'Client successfully redirected back to redirect url' do 
+
+    @instance.state = SecureRandom.uuid
+
+    oauth2_params = {
+      'response_type' => 'code',
+      'client_id' => @instance.client_id,
+      'redirect_uri' => @instance.base_url + '/instance/' + @instance.id + '/' + @instance.client_endpoint_key + '/redirect',
+      'scope' => @instance.scopes,
+      'state' => @instance.state,
+      'aud' => @instance.url
+    }
+
+    oauth2_auth_query = @instance.oauth_authorize_endpoint + "?"
+    oauth2_params.each do |key,value|
+      oauth2_auth_query += "#{key}=#{CGI.escape(value)}&"
+    end
+
+    redirect oauth2_auth_query[0..-2], 'redirect'
   end
+
+  test 'OAuth Server hit redirect url proper values' do
+    assert @params['error'].nil?, "Error returned from authorization server:  code #{@params['error']}, description: #{@params['error_description']}"
+    assert !@params['code'].nil?, "Expected code to be submitted in request"
+  end
+
+  test 'Token exchange endpoint responds.' do
+    oauth2_params = {
+      'grant_type' => 'authorization_code',
+      'code' => @params['code'],
+      'redirect_uri' => @instance.base_url + '/instance/' + @instance.id + '/' + @instance.client_endpoint_key + '/redirect',
+      'client_id' => @instance.client_id
+    }
+
+    # wrap in a rescue and do manual asserts?
+    @token_response = RestClient.post(@instance.oauth_token_endpoint, oauth2_params)
+
+  end
+
+  test 'Data returned from token exchange contains token contains expected information.' do
+    @token_response = JSON.parse(@token_response.body)
+
+    #TODO add assertions here
+
+    token = @token_response['access_token']
+    patient_id = @token_response['patient']
+    scopes = @token_response['scope']
+    @instance.update(token: token, patient_id: patient_id, scopes: scopes)
+
+  end
+
 end

--- a/lib/sequences/03b_provider_ehr_launch_sequence.rb
+++ b/lib/sequences/03b_provider_ehr_launch_sequence.rb
@@ -1,13 +1,99 @@
 class ProviderEHRLaunchSequence < SequenceBase
 
   description 'Provider EHR Launch Sequence'
-  modal_before_run
+  # modal_before_run
   child_test
 
   preconditions 'Client must be registered.' do 
     !@instance.client_id.nil?
   end
 
-  test 'Provider EHR Launch' do
+  test 'Launch url successfully hit' do
+    wait_at_endpoint 'launch'
   end
+
+  test 'iss supplied and is valid' do
+    assert !@params['iss'].nil?, 'Expecting "iss" as a querystring parameter.'
+    # check iss is proper url, ssl, etc?
+  end
+
+  test 'Launch params provided and is valid' do
+    assert !@params['launch'].nil?, 'Expecting "launch" as a querystring parameter.'
+    # check that launch is of the right form
+  end
+
+  test 'Client successfully redirected back to redirect url' do 
+
+    # construct querystring to oauth and redirect after
+
+    @instance.state = SecureRandom.uuid
+
+    #TODO: FIGUREOUT SCOPES
+    scopes = 'launch online_access openid patient/*.* profile'
+
+    binding.pry
+
+    oauth2_params = {
+      'response_type' => 'code',
+      'client_id' => @instance.client_id,
+      'redirect_uri' => @instance.base_url + '/instance/' + @instance.id + '/' + @instance.client_endpoint_key + '/redirect',
+      'scope' => scopes,
+      'launch' => @params['launch'],
+      'state' => @instance.state,
+      'aud' => @params['iss']
+    }
+
+    binding.pry
+
+    oauth2_auth_query = @instance.oauth_authorize_endpoint
+    oauth2_params.each do |key,value|
+      oauth2_auth_query += "#{key}=#{value}&"
+    end
+
+    puts "Launch Authz Query: #{oauth2_auth_query[0..-2]}"
+    binding.pry
+    redirect oauth2_auth_query[0..-2], 'redirect'
+
+  end
+
+  test 'Client redirected to redirect url.' do
+
+    # By virtue of reaching this code, this tests passes
+    assert true
+
+  end
+
+  test 'No error passed in querystring parameter.' do
+    assert !@params['error'].nil?, "Error passed to redirect url: '#{@params['error']}'"
+  end
+
+  test 'Code parameter passed via querystring' do
+
+  end
+
+  test 'Token exchange endpoint responds.' do
+    oauth2_params = {
+      'grant_type' => 'authorization_code',
+      'code' => params['code'],
+      'redirect_uri' => @instance.base_url + '/instance/' + @instance.id + '/' + @instance.client_endpoint_key + '/redirect', # TODO don't hard code base URL
+      'client_id' => @instance.client_id
+    }
+
+    # wrap in a rescue and do manual asserts?
+    @token_response = RestClient.post(@instance.oauth_token_endpoint, oauth2_params)
+
+  end
+
+  test 'Data returned from token exchange contains token contains expected information.' do
+    @token_response = JSON.parse(@token_response.body)
+
+    #TODO add assertions here
+
+    token = token_response['access_token']
+    patient_id = token_response['patient']
+    scopes = token_response['scope']
+    @instance.update(token: token, patient_id: patient_id, scopes: scopes)
+
+  end
+
 end

--- a/lib/sequences/03b_provider_ehr_launch_sequence.rb
+++ b/lib/sequences/03b_provider_ehr_launch_sequence.rb
@@ -14,7 +14,10 @@ class ProviderEHRLaunchSequence < SequenceBase
 
   test 'iss supplied and is valid' do
     assert !@params['iss'].nil?, 'Expecting "iss" as a querystring parameter.'
-    # check iss is proper url, ssl, etc?
+
+    warning {
+      assert @params['iss'] == @instance.url, "'iss' param [#{@params['iss']}] does not match url of testing instance [#{@instance.url}]"
+    }
   end
 
   test 'Launch params provided and is valid' do
@@ -25,13 +28,10 @@ class ProviderEHRLaunchSequence < SequenceBase
   test 'Client successfully redirected back to redirect url' do 
 
     # construct querystring to oauth and redirect after
-
     @instance.state = SecureRandom.uuid
 
     #TODO: FIGUREOUT SCOPES
-    scopes = 'launch online_access openid patient/*.* profile'
-
-    binding.pry
+    scopes = 'launch openid patient/*.* profile'
 
     oauth2_params = {
       'response_type' => 'code',
@@ -43,39 +43,24 @@ class ProviderEHRLaunchSequence < SequenceBase
       'aud' => @params['iss']
     }
 
-    binding.pry
-
-    oauth2_auth_query = @instance.oauth_authorize_endpoint
+    oauth2_auth_query = @instance.oauth_authorize_endpoint + "?"
     oauth2_params.each do |key,value|
-      oauth2_auth_query += "#{key}=#{value}&"
+      oauth2_auth_query += "#{key}=#{CGI.escape(value)}&"
     end
 
-    puts "Launch Authz Query: #{oauth2_auth_query[0..-2]}"
-    binding.pry
     redirect oauth2_auth_query[0..-2], 'redirect'
-
   end
 
-  test 'Client redirected to redirect url.' do
-
-    # By virtue of reaching this code, this tests passes
-    assert true
-
-  end
-
-  test 'No error passed in querystring parameter.' do
-    assert !@params['error'].nil?, "Error passed to redirect url: '#{@params['error']}'"
-  end
-
-  test 'Code parameter passed via querystring' do
-
+  test 'OAuth Server hit redirect url proper values' do
+    assert @params['error'].nil?, "Error returned from authorization server:  code #{@params['error']}, description: #{@params['error_description']}"
+    assert !@params['code'].nil?, "Expected code to be submitted in request"
   end
 
   test 'Token exchange endpoint responds.' do
     oauth2_params = {
       'grant_type' => 'authorization_code',
-      'code' => params['code'],
-      'redirect_uri' => @instance.base_url + '/instance/' + @instance.id + '/' + @instance.client_endpoint_key + '/redirect', # TODO don't hard code base URL
+      'code' => @params['code'],
+      'redirect_uri' => @instance.base_url + '/instance/' + @instance.id + '/' + @instance.client_endpoint_key + '/redirect',
       'client_id' => @instance.client_id
     }
 
@@ -89,9 +74,9 @@ class ProviderEHRLaunchSequence < SequenceBase
 
     #TODO add assertions here
 
-    token = token_response['access_token']
-    patient_id = token_response['patient']
-    scopes = token_response['scope']
+    token = @token_response['access_token']
+    patient_id = @token_response['patient']
+    scopes = @token_response['scope']
     @instance.update(token: token, patient_id: patient_id, scopes: scopes)
 
   end

--- a/lib/sequences/04_token_introspection_sequence.rb
+++ b/lib/sequences/04_token_introspection_sequence.rb
@@ -8,7 +8,7 @@ class TokenIntrospectionSequence < SequenceBase
 
   test 'Token introspection supported' do
 
-    TODO
+    todo
 
   end
 

--- a/lib/sequences/05_argonaut_profiles_sequence.rb
+++ b/lib/sequences/05_argonaut_profiles_sequence.rb
@@ -66,28 +66,28 @@ class ArgonautProfilesSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html',
           'If the data is present, Patient shall include: 2. a communication language' do
 
-    TODO
+    todo
   end
 
   test 'Patient has valid race',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html',
           'If the data is present, Patient shall include: 3. a race' do
 
-    TODO
+    todo
   end
 
   test 'Patient has valid ethnicity',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html',
           'If the data is present, Patient shall include: 4. an ethnicity' do
 
-    TODO
+    todo
   end
 
   test 'Patient has valid birth sex',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html',
           'If the data is present, Patient shall include: 5. a birth sex' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -97,28 +97,28 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has AllergyIntolerance resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-allergyintolerance.html' do
 
-    TODO
+    todo
   end
 
   test 'AllergyIntolerance has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-allergyintolerance.html',
           'Each AllergyIntolerance must have: 1. a status of the allergy' do
 
-    TODO
+    todo
   end
 
   test 'AllergyIntolerance has valid code for substance causing adverse reaction',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-allergyintolerance.html',
           'Each AllergyIntolerance must have: 2. a code which indicates the substance responsible for an adverse reaction' do
 
-    TODO
+    todo
   end
 
   test 'AllergyIntolerance has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-allergyintolerance.html',
           'Each AllergyIntolerance must have: 3. a patient' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -128,35 +128,35 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has CarePlan resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careplan.html' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan has valid narrative summary',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careplan.html',
           'Each CarePlan must have: 1. a narrative summary of the patient assessment and plan of treatment' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careplan.html',
           'Each CarePlan must have: 2. a patient' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careplan.html',
           'Each CarePlan must have: 3. a status' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan has valid category code',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careplan.html',
           'Each CarePlan must have: 4. a category-code of assess-plan' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -166,42 +166,42 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has CareTeam resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careteam.html' do
 
-    TODO
+    todo
   end
 
   test 'CareTeam has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careteam.html',
           'Each CareTeam must have: 1. a patient' do
 
-    TODO
+    todo
   end
 
   test 'CareTeam has valid status code',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careteam.html',
           'Each CareTeam must have: 2. a status code' do
 
-    TODO
+    todo
   end
 
   test 'CareTeam has valid category code',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careteam.html',
           'Each CareTeam must have: 3. a category code of careteam' do
 
-    TODO
+    todo
   end
 
   test 'CareTeam has valid participant roles',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careteam.html',
           'Each CareTeam must have: 4. a participant role for each careteam member' do
 
-    TODO
+    todo
   end
 
   test 'CareTeam has valid names of careteam members',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careteam.html',
           'Each CareTeam must have: 5. names of careteam members' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -211,42 +211,42 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has Condition resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-condition.html' do
 
-    TODO
+    todo
   end
 
   test 'Condition has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-condition.html',
           'Each Condition must have: 1. a patient' do
 
-    TODO
+    todo
   end
 
   test 'Condition has valid code that identifies the problem',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-condition.html',
           'Each Condition must have: 2. a code that identifies the problem' do
 
-    TODO
+    todo
   end
 
   test 'Condition has valid category',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-condition.html',
           'Each Condition must have: 3. a category' do
 
-    TODO
+    todo
   end
 
   test 'Condition has valid status of the problem',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-condition.html',
           'Each Condition must have: 4. a status of the problem' do
 
-    TODO
+    todo
   end
 
   test 'Condition has valid verification status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-condition.html',
           'Each Condition must have: 5. a verification status' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -256,28 +256,28 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has Device resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-device.html' do
 
-    TODO
+    todo
   end
 
   test 'Device has valid code identifying the type of resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-device.html',
           'Each Condition must have: 1. a code identifying the type of resource' do
 
-    TODO
+    todo
   end
 
   test 'Device has valid UDI string',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-device.html',
           'Each Condition must have: 2. a UDI string (udicarrier)' do
 
-    TODO
+    todo
   end
 
   test 'Device has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-device.html',
           'Each Condition must have: 3. a patient' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -287,63 +287,63 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has DiagnosticReport resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html',
           'Each DiagnosticReport must have: 1. a status' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport has valid category code',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html',
           'Each DiagnosticReport must have: 2. a category code of LAB' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport has valid code which tells you what is being measured',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html',
           'Each DiagnosticReport must have: 3. a code (preferably a LOINC code) which tells you what is being measured' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html',
           'Each DiagnosticReport must have: 4. a patient' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport has valid time indicating when the measurement was taken',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html',
           'Each DiagnosticReport must have: 5. a time indicating when the measurement was taken' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport has valid time indicating when the measurement was reported',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html',
           'Each DiagnosticReport must have: 6. a time indicating when the measurement was reported' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport has valid indication of who issues the report',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html',
           'Each DiagnosticReport must have: 7. who issues the report' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport supports valid result(s)',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html',
           'Each DiagnosticReport Must Support: 1. at least one result (discrete observation or image or text representation of the entire result)' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -353,56 +353,56 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has Observation resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html',
           'Each Observation must have: 1. a status' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid category code',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html',
           'Each Observation must have: 2. a category code of laboratory' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid code which tells you what is being measured',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html',
           'Each Observation must have: 3. a LOINC code, if available, which tells you what is being measured' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html',
           'Each Observation must have: 4. a patient' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid result value',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html',
           'Each Observation must have: 5. a result value and, if the result value is a numeric quantity, a standard UCUM unit' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid time indicating when the measurement was taken',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html',
           'Each Observation SHOULD have: 1. a time indicating when the measurement was taken' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid reference range if available',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html',
           'Each Observation SHOULD have: 2. a reference range if available' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -412,28 +412,28 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has Goal resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-goal.html' do
 
-    TODO
+    todo
   end
 
   test 'Goal has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-goal.html',
           'Each Goal must have: 1. a patient' do
 
-    TODO
+    todo
   end
 
   test 'Goal has valid text description of the goal',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-goal.html',
           'Each Goal must have: 2. text description of the goal' do
 
-    TODO
+    todo
   end
 
   test 'Goal has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-goal.html',
           'Each Goal must have: 3. a status' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -443,49 +443,49 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has Immunization resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-immunization.html' do
 
-    TODO
+    todo
   end
 
   test 'Immunization has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-immunization.html',
           'Each Immunization must have: 1. a status' do
 
-    TODO
+    todo
   end
 
   test 'Immunization has valid date',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-immunization.html',
           'Each Immunization must have: 2. a date the vaccine was administered' do
 
-    TODO
+    todo
   end
 
   test 'Immunization has valid vaccine code',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-immunization.html',
           'Each Immunization must have: 3. a vaccine code that identifies the kind of vaccine administered' do
 
-    TODO
+    todo
   end
 
   test 'Immunization has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-immunization.html',
           'Each Immunization must have: 4. a patient' do
 
-    TODO
+    todo
   end
 
   test 'Immunization has valid flag to indicate whether vaccine was given',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-immunization.html',
           'Each Immunization must have: 5. a flag to indicate whether vaccine was given' do
 
-    TODO
+    todo
   end
 
   test 'Immunization has valid a flag to indicate whether the vaccine was reported by patient rather than directly administered',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-immunization.html',
           'Each Immunization must have: 6. a flag to indicate whether the vaccine was reported by patient rather than directly administered' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -495,14 +495,14 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has Medication resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medication.html' do
 
-    TODO
+    todo
   end
 
   test 'Medication has valid medication code',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medication.html',
           'Each Medication must have: 1. a medication code' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -512,42 +512,42 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has MedicationOrder resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html' do
 
-    TODO
+    todo
   end
 
   test 'MedicationOrder has valid date for when written',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html',
           'Each MedicationOrder must have: 1. a date for when written' do
 
-    TODO
+    todo
   end
 
   test 'MedicationOrder has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html',
           'Each MedicationOrder must have: 2. a status' do
 
-    TODO
+    todo
   end
 
   test 'MedicationOrder has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html',
           'Each MedicationOrder must have: 3. a patient' do
 
-    TODO
+    todo
   end
 
   test 'MedicationOrder has valid prescriber',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html',
           'Each MedicationOrder must have: 4. a prescriber' do
 
-    TODO
+    todo
   end
 
   test 'MedicationOrder has valid medication',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html',
           'Each MedicationOrder must have: 5. a medication' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -557,35 +557,35 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has MedicationStatement resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationstatement.html' do
 
-    TODO
+    todo
   end
 
   test 'MedicationStatement has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationstatement.html',
           'Each MedicationOrder must have: 1. a patient' do
 
-    TODO
+    todo
   end
 
   test 'MedicationStatement has valid date',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationstatement.html',
           'Each MedicationOrder must have: 2. a date' do
 
-    TODO
+    todo
   end
 
   test 'MedicationStatement has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationstatement.html',
           'Each MedicationOrder must have: 3. a status' do
 
-    TODO
+    todo
   end
 
   test 'MedicationStatement has valid medication',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationstatement.html',
           'Each MedicationOrder must have: 4. a medication' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -595,35 +595,35 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has Procedure resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-procedure.html' do
 
-    TODO
+    todo
   end
 
   test 'Procedure has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-procedure.html',
           'Each Procedure must have: 1. a patient' do
 
-    TODO
+    todo
   end
 
   test 'Procedure has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-procedure.html',
           'Each Procedure must have: 2. a status' do
 
-    TODO
+    todo
   end
 
   test 'Procedure has valid procedure code',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-procedure.html',
           'Each Procedure must have: 3. a code that identifies the type of procedure performed on the patient' do
 
-    TODO
+    todo
   end
 
   test 'Procedure has valid time indicating when the procedure was performed',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-procedure.html',
           'Each Procedure must have: 4. when the procedure was performed' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -633,42 +633,42 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has Observation resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-smokingstatus.html' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-smokingstatus.html',
           'Each Observation must have: 1. a status' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid fixed code for smoking observation',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-smokingstatus.html',
           'Each Observation must have: 2. a fixed code for smoking observation' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-smokingstatus.html',
           'Each Observation must have: 3. a patient' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid date representing when the smoking status was recorded',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-smokingstatus.html',
           'Each Observation must have: 4. a date representing when the smoking status was recorded' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid result value code for smoking status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-smokingstatus.html',
           'Each Observation must have: 5. a result value code for smoking status' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -678,49 +678,49 @@ class ArgonautProfilesSequence < SequenceBase
   test 'Has Observation resource',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-vitalsigns.html' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid status',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-vitalsigns.html',
           'Each Observation must have: 1. a status' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid category',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-vitalsigns.html',
           'Each Observation must have: 2. a category code of vital-signs' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid code which tells you what is being measured',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-vitalsigns.html',
           'Each Observation must have: 3. a LOINC code which tells you what is being measured' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid patient',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-vitalsigns.html',
           'Each Observation must have: 4. a patient' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid a time indicating when the measurement was taken',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-vitalsigns.html',
           'Each Observation must have: 5. a time indicating when the measurement was taken' do
 
-    TODO
+    todo
   end
 
   test 'Observation has valid numeric result value and standard UCUM unit',
           'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-vitalsigns.html',
           'Each Observation must have: 6. a numeric result value and standard UCUM unit' do
 
-    TODO
+    todo
   end
 
 end

--- a/lib/sequences/06_argonaut_search_sequence.rb
+++ b/lib/sequences/06_argonaut_search_sequence.rb
@@ -14,70 +14,70 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: name' do
 
-    TODO
+    todo
   end
 
   test 'Patient search by family',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: family' do
 
-    TODO
+    todo
   end
 
   test 'Patient search by given',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: given' do
 
-    TODO
+    todo
   end
 
   test 'Patient search by identifier',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: identifier' do
 
-    TODO
+    todo
   end
 
   test 'Patient search by gender',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: gender' do
 
-    TODO
+    todo
   end
 
   test 'Patient search by birthdate',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: birthdate' do
 
-    TODO
+    todo
   end
 
   test 'Patient search by name + gender',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: name + gender' do
 
-    TODO
+    todo
   end
 
   test 'Patient search by name + birthdate',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: name + birthdate' do
 
-    TODO
+    todo
   end
 
   test 'Patient search by family + gender',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: family + gender' do
 
-    TODO
+    todo
   end
 
   test 'Patient search by given + gender',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: given + gender' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -88,7 +88,7 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -99,56 +99,56 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan search by category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: category' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan search by status',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: status' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan search by date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: date' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan search by patient + category + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category + date' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan search by patient + category + status',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category + status' do
 
-    TODO
+    todo
   end
 
   test 'CarePlan search by patient + category + status + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category + status + date' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -159,35 +159,35 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   test 'Condition search by category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: category' do
 
-    TODO
+    todo
   end
 
   test 'Condition search by clinicalstatus',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: clinicalstatus' do
 
-    TODO
+    todo
   end
 
   test 'Condition search by patient + clinicalstatus',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + clinicalstatus' do
 
-    TODO
+    todo
   end
 
   test 'Condition search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -198,7 +198,7 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -209,21 +209,21 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   test 'Goal search by date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: date' do
 
-    TODO
+    todo
   end
 
   test 'Goal search by patient + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + date' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -234,7 +234,7 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -245,56 +245,56 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport search by category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: category' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport search by code',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: code' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport search by date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: date' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport search by patient + category + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category + date' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport search by patient + category + code',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category + code' do
 
-    TODO
+    todo
   end
 
   test 'DiagnosticReport search by patient + category + code + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category + code + date' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -309,7 +309,7 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -320,7 +320,7 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -331,56 +331,56 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   test 'Observation search by category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: category' do
 
-    TODO
+    todo
   end
 
   test 'Observation search by code',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: code' do
 
-    TODO
+    todo
   end
 
   test 'Observation search by date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: date' do
 
-    TODO
+    todo
   end
 
   test 'Observation search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category' do
 
-    TODO
+    todo
   end
 
   test 'Observation search by patient + category + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category + date' do
 
-    TODO
+    todo
   end
 
   test 'Observation search by patient + category + code',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category + code' do
 
-    TODO
+    todo
   end
 
   test 'Observation search by patient + category + code + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + category + code + date' do
 
-    TODO
+    todo
   end
 
   # --------------------------------------------------
@@ -391,21 +391,21 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    TODO
+    todo
   end
 
   test 'Procedure search by date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: date' do
 
-    TODO
+    todo
   end
 
   test 'Procedure search by patient + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient + date' do
 
-    TODO
+    todo
   end
 
 end

--- a/lib/utils/assertions.rb
+++ b/lib/utils/assertions.rb
@@ -1,3 +1,5 @@
+require_relative 'assertions'
+
 module Assertions
 
   def assert(test, message="assertion failed, no message", data="")
@@ -247,21 +249,5 @@ module Assertions
     raise SkipException.new message
   end
 
-end
-
-class AssertionException < Exception
-  attr_accessor :data
-  def initialize(message, data=nil)
-    super(message)
-    FHIR.logger.error "AssertionException: #{message}"
-    @data = data
-  end
-end
-
-class SkipException < Exception
-  def initialize(message = '')
-    super(message)
-    FHIR.logger.info "SkipException: #{message}"
-  end
 end
 

--- a/lib/utils/exceptions.rb
+++ b/lib/utils/exceptions.rb
@@ -1,0 +1,41 @@
+class AssertionException < Exception
+  attr_accessor :data
+  def initialize(message, data=nil)
+    super(message)
+    FHIR.logger.error "AssertionException: #{message}"
+    @data = data
+  end
+end
+
+# WILL WE NEED THIS?
+class SkipException < Exception
+  def initialize(message = '')
+    super(message)
+    FHIR.logger.info "SkipException: #{message}"
+  end
+end
+
+class TodoException < Exception
+  def initialize(message = '')
+    super(message)
+    FHIR.logger.info "TodoException: #{message}"
+  end
+end
+
+class WaitException < Exception
+  attr_accessor :endpoint
+  def initialize(endpoint)
+    super("Waiting at endpoint #{endpoint}")
+    @endpoint = endpoint
+  end
+end
+
+class RedirectException < Exception
+  attr_accessor :endpoint
+  attr_accessor :url
+  def initialize(url, endpoint)
+    super("Redirecting to #{url} and waiting at endpoint #{endpoint}")
+    @url = url
+    @endpoint = endpoint
+  end
+end

--- a/models/SequenceResult.rb
+++ b/models/SequenceResult.rb
@@ -3,12 +3,16 @@ class SequenceResult
   property :id, String, key: true
   property :name, String
   property :result, String #pass fail
+  property :created_at, DateTime, default: proc { DateTime.now }
+
+  property :redirect_to_url, String
+  property :wait_at_endpoint, String
+
   property :passed_count, Integer, default: 0
   property :failed_count, Integer, default: 0
   property :error_count, Integer, default: 0
   property :warning_count, Integer, default: 0
   property :todo_count, Integer, default: 0
-  property :created_at, DateTime, default: proc { DateTime.now }
 
   has n, :test_results, order: [:created_at.asc]
   belongs_to :testing_instance

--- a/models/SequenceResult.rb
+++ b/models/SequenceResult.rb
@@ -14,6 +14,6 @@ class SequenceResult
   property :warning_count, Integer, default: 0
   property :todo_count, Integer, default: 0
 
-  has n, :test_results, order: [:created_at.asc]
+  has n, :test_results, order: [:test_index.asc]
   belongs_to :testing_instance
 end

--- a/models/TestResult.rb
+++ b/models/TestResult.rb
@@ -10,6 +10,9 @@ class TestResult
   property :description, Text
   property :created_at, DateTime, default: proc { DateTime.now }
 
+  property :wait_at_endpoint, String
+  property :redirect_to_url, String
+
   has n, :request_responses, :through => Resource 
   belongs_to :sequence_result
 end

--- a/models/TestResult.rb
+++ b/models/TestResult.rb
@@ -8,11 +8,13 @@ class TestResult
 
   property :url, String, length: 500
   property :description, Text
+  property :test_index, Integer
   property :created_at, DateTime, default: proc { DateTime.now }
 
   property :wait_at_endpoint, String
   property :redirect_to_url, String
 
   has n, :request_responses, :through => Resource 
+  has n, :warnings
   belongs_to :sequence_result
 end

--- a/models/TestingInstance.rb
+++ b/models/TestingInstance.rb
@@ -4,8 +4,11 @@ class TestingInstance
   property :url, String
   property :name, String
   property :client_id, String
+  property :base_url, String
+
   property :scopes, String
   property :launch_type, String
+  property :state, String
 
   property :conformance_checked, Boolean
   property :oauth_authorize_endpoint, String
@@ -25,5 +28,9 @@ class TestingInstance
 
   def latest_results
     self.sequence_results.reduce({}) { |hash, result| hash[result.name] = result if hash[result.name].nil? || hash[result.name].created_at < result.created_at; hash}
+  end
+
+  def waiting_on_sequence
+    self.sequence_results.first(result: 'wait')
   end
 end

--- a/models/TestingInstance.rb
+++ b/models/TestingInstance.rb
@@ -27,7 +27,12 @@ class TestingInstance
   has n, :sequence_results
 
   def latest_results
-    self.sequence_results.reduce({}) { |hash, result| hash[result.name] = result if hash[result.name].nil? || hash[result.name].created_at < result.created_at; hash}
+    self.sequence_results.reduce({}) do |hash, result| 
+      if hash[result.name].nil? || hash[result.name].created_at < result.created_at
+        hash[result.name] = result 
+      end
+      hash
+    end
   end
 
   def waiting_on_sequence

--- a/models/Warning.rb
+++ b/models/Warning.rb
@@ -1,0 +1,7 @@
+class Warning
+  include DataMapper::Resource
+  property :id, Serial
+  property :message, String, length: 500
+
+  belongs_to :test_result
+end

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -296,6 +296,10 @@
   color: #336699;
 }
 
+.result-details-icon-warning {
+  color: #FFFF33;
+}
+
 .result-details-message {
   margin-left: 19px;
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -111,6 +111,12 @@
   border: 2px solid #fff;
 }
 
+.scorecard-score-wait {
+  background-color: #336699;
+  color: #fff;
+  border: 2px solid #fff;
+}
+
 .scorecard-score-skip {
   background-color: #FF7F50;
   color: #FFF;
@@ -283,6 +289,10 @@
 }
 
 .result-details-icon-todo {
+  color: #336699;
+}
+
+.result-details-icon-wait {
   color: #336699;
 }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -34,4 +34,6 @@ $(function(){
 
   $('[data-toggle="tooltip"]').tooltip()
 
+  $('#WaitModal').modal('show');
+
 })

--- a/views/details.erb
+++ b/views/details.erb
@@ -230,7 +230,7 @@
           Waiting for redirect at: <br/><%=redirect_to %>
           </p>
           <div class="modal-footer">
-            <a href="<%=redirect_to%>" class="btn btn-secondary">Cancel Sequence</a>
+            <a href="<%= "#{request.base_url}/instance/#{@instance.id}/sequence_result/#{waiting_on_sequence.id}/cancel" %>" class="btn btn-secondary">Cancel Sequence</a>
           </div>
         </div>
       </div>

--- a/views/details.erb
+++ b/views/details.erb
@@ -213,6 +213,31 @@
   </div>
 </div>
 
+<% waiting_on_sequence = @instance.waiting_on_sequence %>
+<% unless waiting_on_sequence.nil? %>
+  <% redirect_to = "#{request.base_url}/instance/#{@instance.id}/#{@instance.client_endpoint_key}/#{waiting_on_sequence.wait_at_endpoint}" %>
+  <div class="modal fade" id="WaitModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" data-show="true">
+    <div class="modal-dialog modal-lg" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLabel">Waiting for Server Redirect</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <p>
+          Waiting for redirect at: <br/><%=redirect_to %>
+          </p>
+          <div class="modal-footer">
+            <a href="<%=redirect_to%>" class="btn btn-secondary">Cancel Sequence</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <div class="modal fade" id="stateModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">

--- a/views/result.erb
+++ b/views/result.erb
@@ -19,6 +19,10 @@
             <div class="result-details-icon result-details-icon-skip">
               <span class="oi oi-warning" title="Skip" aria-hidden="true"></span>
             </div>
+        <% when 'wait' %>
+            <div class="result-details-icon result-details-icon-wait">
+              <span class="oi oi-media-pause" title="waiting" aria-hidden="true"></span>
+            </div>
         <% when 'todo' %>
             <div class="result-details-icon result-details-icon-todo">
               <span class="oi oi-minus" title="todo" aria-hidden="true"></span>

--- a/views/result.erb
+++ b/views/result.erb
@@ -28,6 +28,12 @@
               <span class="oi oi-minus" title="todo" aria-hidden="true"></span>
             </div>
         <% end %>
+        <% if result.warnings.length > 0 %>
+            <div class="result-details-icon result-details-icon-warning">
+              <span class="oi oi-warning" title="todo" aria-hidden="true"></span>
+            </div>
+        <% end %>
+
         <% if result.result == 'todo' %> TODO: <% end %>
         <%= result.name %>
         <% if result.result == 'fail' || result.result == 'error' %>

--- a/views/sequence.erb
+++ b/views/sequence.erb
@@ -13,6 +13,10 @@
       <div class="scorecard-score scorecard-score-fail">
         <span class="oi oi-x" title="Fail" aria-hidden="true"></span>
       </div>
+  <% when 'cancel' %>
+      <div class="scorecard-score scorecard-score-fail">
+        <span class="oi oi-x" title="Cancel" aria-hidden="true"></span>
+      </div>
   <% when 'error' %>
       <div class="scorecard-score scorecard-score-error">
         !

--- a/views/sequence.erb
+++ b/views/sequence.erb
@@ -17,6 +17,10 @@
       <div class="scorecard-score scorecard-score-error">
         !
       </div>
+  <% when 'wait' %>
+      <div class="scorecard-score scorecard-score-wait">
+        <span class="oi oi-media-pause" title="waiting" aria-hidden="true"></span>
+      </div>
   <% when 'skip' %>
       <div class="scorecard-score scorecard-score-skip">
         <span class="oi oi-warning" title="Skip" aria-hidden="true"></span>

--- a/views/test_result_details.erb
+++ b/views/test_result_details.erb
@@ -37,6 +37,16 @@
       </div>
     <% end %>
 
+    <% unless @test_result.warnings.empty? %>
+      <div class="test-result-details-warnings">
+        <% @test_result.warnings.each do |w| %>
+          <div>
+          warning: <%= w.message %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+
     <% unless @test_result.url.nil? %>
       <div class="test-result-details-url">
         <span class="test-result-details-url-label">URL:</span> <a href="<%=@test_result.url%>" target="_blank"><%= @test_result.url %></a>


### PR DESCRIPTION
Sequences can now be paused mid-execution to handle redirects to other sites, and the sequences pick up on the next test when redirected back, while making data from the request available `@params[]`.  This way our launch tests read linearly, top to bottom.  See the EHR launch and Patient launches for examples.

I'm not quite 100% sure that I nailed down all edge cases.  And I may want to add in another way to pause -- to gather user input in a generic way.  But I think this probably is good enough for next week.

I also added in a method to do warnings from plan_executor (for optional requirements).  See EHR Launch... just add things inside a 
```ruby
warning {
   assert ...
}
```