### PR TITLE
Rename warning class and other db updates

### DIFF
--- a/models/RequestResponse.rb
+++ b/models/RequestResponse.rb
@@ -1,6 +1,6 @@
 class RequestResponse
   include DataMapper::Resource
-  property :id, String, key: true
+  property :id, String, key: true, default: proc { SecureRandom.uuid}
   property :request_method, String
   property :request_url, String, length: 500
   property :request_headers, String, length: 1000

--- a/models/SequenceResult.rb
+++ b/models/SequenceResult.rb
@@ -1,11 +1,10 @@
 class SequenceResult
   include DataMapper::Resource
-  property :id, String, key: true
+  property :id, String, key: true, default: proc { SecureRandom.uuid}
   property :name, String
-  property :result, String #pass fail
-  property :created_at, DateTime, default: proc { DateTime.now }
+  property :result, String
 
-  property :redirect_to_url, String
+  property :redirect_to_url, String, length: 500
   property :wait_at_endpoint, String
 
   property :passed_count, Integer, default: 0
@@ -13,6 +12,8 @@ class SequenceResult
   property :error_count, Integer, default: 0
   property :warning_count, Integer, default: 0
   property :todo_count, Integer, default: 0
+
+  property :created_at, DateTime, default: proc { DateTime.now }
 
   has n, :test_results, order: [:test_index.asc]
   belongs_to :testing_instance

--- a/models/TestResult.rb
+++ b/models/TestResult.rb
@@ -1,10 +1,9 @@
 class TestResult
   include DataMapper::Resource
-  property :id, String, key: true
+  property :id, String, key: true, default: proc { SecureRandom.uuid}
   property :name, String
   property :result, String
-  property :warning, String
-  property :message, String
+  property :message, String, length: 500
 
   property :url, String, length: 500
   property :description, Text
@@ -15,6 +14,6 @@ class TestResult
   property :redirect_to_url, String
 
   has n, :request_responses, :through => Resource 
-  has n, :warnings
+  has n, :test_warnings
   belongs_to :sequence_result
 end

--- a/models/TestWarning.rb
+++ b/models/TestWarning.rb
@@ -1,6 +1,6 @@
-class Warning
+class TestWarning
   include DataMapper::Resource
-  property :id, Serial
+  property :id, String, key: true, default: proc { SecureRandom.uuid}
   property :message, String, length: 500
 
   belongs_to :test_result

--- a/models/TestingInstance.rb
+++ b/models/TestingInstance.rb
@@ -1,6 +1,6 @@
 class TestingInstance
   include DataMapper::Resource
-  property :id, String, key: true
+  property :id, String, key: true, default: proc { SecureRandomBase62.generate(32) }
   property :url, String
   property :name, String
   property :client_id, String

--- a/views/result.erb
+++ b/views/result.erb
@@ -28,7 +28,7 @@
               <span class="oi oi-minus" title="todo" aria-hidden="true"></span>
             </div>
         <% end %>
-        <% if result.warnings.length > 0 %>
+        <% if result.test_warnings.length > 0 %>
             <div class="result-details-icon result-details-icon-warning">
               <span class="oi oi-warning" title="todo" aria-hidden="true"></span>
             </div>

--- a/views/test_result_details.erb
+++ b/views/test_result_details.erb
@@ -37,9 +37,9 @@
       </div>
     <% end %>
 
-    <% unless @test_result.warnings.empty? %>
+    <% unless @test_result.test_warnings.empty? %>
       <div class="test-result-details-warnings">
-        <% @test_result.warnings.each do |w| %>
+        <% @test_result.test_warnings.each do |w| %>
           <div>
           warning: <%= w.message %>
           </div>


### PR DESCRIPTION
DB updates based on issues uncovered Friday

* Renamed Warning to TestWarning so works in Ruby 2.4.0 now
* id's are now automatically generated for models, so no need to pass explicitly when making new ones
* Added a flag at the top of app.rb to allow you to do incremental updates instead of full purges.  We should do full purges by default for now to reduce confusion on team (e.g. don't change that line and commit it)
* removed a few db fields that we don't need any more, since I was doing db updates anyhow