### PR TITLE
Search tests

### DIFF
--- a/lib/sequences/06_argonaut_search_sequence.rb
+++ b/lib/sequences/06_argonaut_search_sequence.rb
@@ -8,8 +8,8 @@ class ArgonautSearchSequence < SequenceBase
     !@instance.token.nil?
   end
 
-  def get_patient_by_param(params = {}, flag = true)
-    assert !params.empty?, "No params for patient"
+  def get_resource_by_params(klass, params = {}, flag = true)
+    assert !params.empty?, "No params for search"
     options = {
       :search => {
         :flag => flag,
@@ -17,11 +17,15 @@ class ArgonautSearchSequence < SequenceBase
         :parameters => params
       }
     }
-    reply = @client.search(FHIR::DSTU2::Patient, options)
+    reply = @client.search(klass, options)
     assert_response_ok(reply)
     assert_bundle_response(reply)
-    assert !reply.resource.get_by_id(@instance.patient_id).nil?, 'Server returned nil patient.'
-    assert reply.resource.get_by_id(@instance.patient_id).equals?(@patient, ['_id', "text", "meta", "lastUpdated"]), 'Server returned wrong patient.'
+
+    #TODO Implement basic validation of resources other than FHIR::DSTU2::Patient
+    if klass == FHIR::DSTU2::Patient
+      assert !reply.resource.get_by_id(@patient_id).nil?, 'Server returned nil patient'
+      assert reply.resource.get_by_id(@patient_id).equals?(@patient, ['_id', "text", "meta", "lastUpdated"]), 'Server returned wrong patient'
+    end
   end
 
   # --------------------------------------------------
@@ -29,7 +33,7 @@ class ArgonautSearchSequence < SequenceBase
   # --------------------------------------------------
 
   test 'Has Patient resource',
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html' do
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html' do
 
     patient_read_response = @client.read(FHIR::DSTU2::Patient, @instance.patient_id)
     assert_response_ok patient_read_response
@@ -37,6 +41,7 @@ class ArgonautSearchSequence < SequenceBase
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
     @patient_details = @patient.to_hash
     assert @patient.is_a?(FHIR::DSTU2::Patient), 'Expected resource to be valid DSTU2 Patient'
+
   end
 
   test 'Patient search by name',
@@ -47,7 +52,7 @@ class ArgonautSearchSequence < SequenceBase
     assert family, "Patient family name not returned"
     given = @patient_details['name'][0]['given'][0]
     assert given, "Patient given name not returned"
-    get_patient_by_param(family: family, given: given)
+    get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given})
 
   end
 
@@ -57,7 +62,7 @@ class ArgonautSearchSequence < SequenceBase
 
     family = @patient_details['name'][0]['family'][0]
     assert family, "Patient family name not returned"
-    get_patient_by_param(family: family)
+    get_resource_by_params(FHIR::DSTU2::Patient, {family: family})
 
   end
 
@@ -67,7 +72,7 @@ class ArgonautSearchSequence < SequenceBase
 
     given = @patient_details['name'][0]['given'][0]
     assert given, "Patient given name not returned"
-    get_patient_by_param(given: given)
+    get_resource_by_params(FHIR::DSTU2::Patient, {given: given})
 
   end
 
@@ -77,7 +82,7 @@ class ArgonautSearchSequence < SequenceBase
 
     identifier = @patient_details['identifier'][0]['value']
     assert identifier, "Patient identifier not returned"
-    get_patient_by_param(identifier: identifier)
+    get_resource_by_params(FHIR::DSTU2::Patient, {identifier: identifier})
 
   end
 
@@ -87,7 +92,7 @@ class ArgonautSearchSequence < SequenceBase
 
     gender = @patient_details['gender']
     assert gender, "Patient gender not returned"
-    get_patient_by_param(gender: gender)
+    get_resource_by_params(FHIR::DSTU2::Patient, {gender: gender})
 
   end
 
@@ -97,7 +102,7 @@ class ArgonautSearchSequence < SequenceBase
 
     birthdate = @patient_details['birthDate']
     assert birthdate, "Patient birthdate not returned"
-    get_patient_by_param(birthdate: birthdate)
+    get_resource_by_params(FHIR::DSTU2::Patient, {birthdate: birthdate})
 
   end
 
@@ -111,7 +116,7 @@ class ArgonautSearchSequence < SequenceBase
     assert given, "Patient given name not returned"
     gender = @patient_details['gender']
     assert gender, "Patient gender not returned"
-    get_patient_by_param(family: family, given: given, gender: gender)
+    get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, gender: gender})
 
   end
 
@@ -125,7 +130,7 @@ class ArgonautSearchSequence < SequenceBase
     assert given, "Patient given name not returned"
     birthdate = @patient_details['birthDate']
     assert birthdate, "Patient birthDate not returned"
-    get_patient_by_param(family: family, given: given, birthdate: birthdate)
+    get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, birthdate: birthdate})
 
   end
 
@@ -137,7 +142,7 @@ class ArgonautSearchSequence < SequenceBase
     assert family, "Patient family name not returned"
     gender = @patient_details['gender']
     assert gender, "Patient gender not returned"
-    get_patient_by_param(family: family, gender: gender)
+    get_resource_by_params(FHIR::DSTU2::Patient, {family: family, gender: gender})
 
   end
 
@@ -149,7 +154,7 @@ class ArgonautSearchSequence < SequenceBase
     assert given, "Patient given name not returned"
     gender = @patient_details['gender']
     assert gender, "Patient gender not returned"
-    get_patient_by_param(given: given, gender: gender)
+    get_resource_by_params(FHIR::DSTU2::Patient, {given: given, gender: gender})
 
   end
 
@@ -161,7 +166,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::AllergyIntolerance, {patient: @instance.patient_id})
+
   end
 
   # --------------------------------------------------
@@ -172,7 +178,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id})
+
   end
 
   test 'CarePlan search by category',
@@ -232,7 +239,9 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id})
+
+
   end
 
   test 'Condition search by category',
@@ -271,7 +280,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::Device, {patient: @instance.patient_id})
+
   end
 
   # --------------------------------------------------
@@ -282,7 +292,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::Goal, {patient: @instance.patient_id})
+
   end
 
   test 'Goal search by date',
@@ -307,7 +318,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::Immunization, {patient: @instance.patient_id})
+
   end
 
   # --------------------------------------------------
@@ -318,7 +330,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id})
+
   end
 
   test 'DiagnosticReport search by category',
@@ -382,7 +395,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::MedicationStatement, {patient: @instance.patient_id})
+
   end
 
   # --------------------------------------------------
@@ -393,7 +407,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::MedicationOrder, {patient: @instance.patient_id})
+
   end
 
   # --------------------------------------------------
@@ -404,7 +419,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id})
+
   end
 
   test 'Observation search by category',
@@ -464,7 +480,8 @@ class ArgonautSearchSequence < SequenceBase
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'Supported Searches: patient' do
 
-    todo
+    get_resource_by_params(FHIR::DSTU2::Procedure, {patient: @instance.patient_id})
+
   end
 
   test 'Procedure search by date',

--- a/lib/sequences/06_argonaut_search_sequence.rb
+++ b/lib/sequences/06_argonaut_search_sequence.rb
@@ -8,23 +8,35 @@ class ArgonautSearchSequence < SequenceBase
     !@instance.token.nil?
   end
 
-  def get_resource_by_params(klass, params = {}, flag = true)
+  def get_resource_by_params(klass, params = {})
     assert !params.empty?, "No params for search"
     options = {
       :search => {
-        :flag => flag,
+        :flag => false,
         :compartment => nil,
         :parameters => params
       }
     }
     reply = @client.search(klass, options)
+  end
+
+  def validate_resource_by_params(klass, reply)
     assert_response_ok(reply)
     assert_bundle_response(reply)
 
-    #TODO Implement basic validation of resources other than FHIR::DSTU2::Patient
     if klass == FHIR::DSTU2::Patient
-      assert !reply.resource.get_by_id(@patient_id).nil?, 'Server returned nil patient'
-      assert reply.resource.get_by_id(@patient_id).equals?(@patient, ['_id', "text", "meta", "lastUpdated"]), 'Server returned wrong patient'
+      assert !reply.resource.get_by_id(@instance.patient_id).nil?, 'Server returned nil patient'
+      assert reply.resource.get_by_id(@instance.patient_id).equals?(@patient, ['_id', "text", "meta", "lastUpdated"]), 'Server returned wrong patient'
+    elsif [FHIR::DSTU2::CarePlan, FHIR::DSTU2::Goal, FHIR::DSTU2::DiagnosticReport, FHIR::DSTU2::Observation, FHIR::DSTU2::Procedure].include?(klass)
+      assert reply.resource.entry.length > 0, 'No resources of this type were returned'
+      reply.resource.entry.each do |entry|
+        assert (entry.resource.subject && entry.resource.subject.reference.include?(@instance.patient_id)), "Subject on resource does not match patient requested"
+      end
+    else
+      assert reply.resource.entry.length > 0, 'No resources of this type were returned'
+      reply.resource.entry.each do |entry|
+        assert (entry.resource.patient && entry.resource.patient.reference.include?(@instance.patient_id)), "Patient on resource does not match patient requested"
+      end
     end
   end
 
@@ -33,128 +45,73 @@ class ArgonautSearchSequence < SequenceBase
   # --------------------------------------------------
 
   test 'Has Patient resource',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html' do
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A server is capable of returning a patient using GET [base]/Patient/[id]' do
 
     patient_read_response = @client.read(FHIR::DSTU2::Patient, @instance.patient_id)
     assert_response_ok patient_read_response
     @patient = patient_read_response.resource
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
-    @patient_details = @patient.to_hash
+    @patient_hash = @patient.to_hash
     assert @patient.is_a?(FHIR::DSTU2::Patient), 'Expected resource to be valid DSTU2 Patient'
-
-  end
-
-  test 'Patient search by name',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: name' do
-
-    family = @patient_details['name'][0]['family'][0]
-    assert family, "Patient family name not returned"
-    given = @patient_details['name'][0]['given'][0]
-    assert given, "Patient given name not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given})
-
-  end
-
-  test 'Patient search by family',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: family' do
-
-    family = @patient_details['name'][0]['family'][0]
-    assert family, "Patient family name not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {family: family})
-
-  end
-
-  test 'Patient search by given',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: given' do
-
-    given = @patient_details['name'][0]['given'][0]
-    assert given, "Patient given name not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {given: given})
 
   end
 
   test 'Patient search by identifier',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: identifier' do
+          'A server has exposed a FHIR Patient search endpoint supporting at a minimum the following search parameters: identifier' do
 
-    identifier = @patient_details['identifier'][0]['value']
+    assert !(@patient_hash.nil? || @patient_hash.empty?), 'No Patient resource available'
+    identifier = @patient_hash['identifier'][0]['value']
     assert identifier, "Patient identifier not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {identifier: identifier})
-
-  end
-
-  test 'Patient search by gender',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: gender' do
-
-    gender = @patient_details['gender']
-    assert gender, "Patient gender not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {gender: gender})
-
-  end
-
-  test 'Patient search by birthdate',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: birthdate' do
-
-    birthdate = @patient_details['birthDate']
-    assert birthdate, "Patient birthdate not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {birthdate: birthdate})
+    reply = get_resource_by_params(FHIR::DSTU2::Patient, {identifier: identifier})
+    validate_resource_by_params(FHIR::DSTU2::Patient, reply)
 
   end
 
   test 'Patient search by name + gender',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: name + gender' do
+          'A server has exposed a FHIR Patient search endpoint supporting at a minimum the following search parameters when at least 2 (example name and gender) are present: name, gender, birthdate' do
 
-    family = @patient_details['name'][0]['family'][0]
+    assert !(@patient_hash.nil? || @patient_hash.empty?), 'No Patient resource available'
+    family = @patient_hash['name'][0]['family'][0]
     assert family, "Patient family name not returned"
-    given = @patient_details['name'][0]['given'][0]
+    given = @patient_hash['name'][0]['given'][0]
     assert given, "Patient given name not returned"
-    gender = @patient_details['gender']
+    gender = @patient_hash['gender']
     assert gender, "Patient gender not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, gender: gender})
+    reply = get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, gender: gender})
+    validate_resource_by_params(FHIR::DSTU2::Patient, reply)
 
   end
 
   test 'Patient search by name + birthdate',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: name + birthdate' do
+          'A server has exposed a FHIR Patient search endpoint supporting at a minimum the following search parameters when at least 2 (example name and gender) are present: name, gender, birthdate' do
 
-    family = @patient_details['name'][0]['family'][0]
+    assert !(@patient_hash.nil? || @patient_hash.empty?), 'No Patient resource available'
+    family = @patient_hash['name'][0]['family'][0]
     assert family, "Patient family name not returned"
-    given = @patient_details['name'][0]['given'][0]
+    given = @patient_hash['name'][0]['given'][0]
     assert given, "Patient given name not returned"
-    birthdate = @patient_details['birthDate']
+    birthdate = @patient_hash['birthDate']
     assert birthdate, "Patient birthDate not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, birthdate: birthdate})
+    reply = get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, birthdate: birthdate})
+    validate_resource_by_params(FHIR::DSTU2::Patient, reply)
 
   end
 
-  test 'Patient search by family + gender',
+  test 'Patient search by gender + birthdate',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: family + gender' do
+          'A server has exposed a FHIR Patient search endpoint supporting at a minimum the following search parameters when at least 2 (example name and gender) are present: name, gender, birthdate' do
 
-    family = @patient_details['name'][0]['family'][0]
-    assert family, "Patient family name not returned"
-    gender = @patient_details['gender']
+    assert !(@patient_hash.nil? || @patient_hash.empty?), 'No Patient resource available'
+    gender = @patient_hash['gender']
     assert gender, "Patient gender not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {family: family, gender: gender})
-
-  end
-
-  test 'Patient search by given + gender',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: given + gender' do
-
-    given = @patient_details['name'][0]['given'][0]
-    assert given, "Patient given name not returned"
-    gender = @patient_details['gender']
-    assert gender, "Patient gender not returned"
-    get_resource_by_params(FHIR::DSTU2::Patient, {given: given, gender: gender})
+    birthdate = @patient_hash['birthDate']
+    assert birthdate, "Patient birthDate not returned"
+    reply = get_resource_by_params(FHIR::DSTU2::Patient, {gender: gender, birthdate: birthdate})
+    validate_resource_by_params(FHIR::DSTU2::Patient, reply)
 
   end
 
@@ -164,9 +121,11 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'AllergyIntolerance search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
+          'A server is capable of returning a patient’s allergies using GET /AllergyIntolerance?patient=[id]' do
 
-    get_resource_by_params(FHIR::DSTU2::AllergyIntolerance, {patient: @instance.patient_id})
+    reply = get_resource_by_params(FHIR::DSTU2::AllergyIntolerance, {patient: @instance.patient_id})
+    @allergyintolerance_hash = reply.resource.entry[0].to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::AllergyIntolerance, reply)
 
   end
 
@@ -174,61 +133,54 @@ class ArgonautSearchSequence < SequenceBase
   # CarePlan Search
   # --------------------------------------------------
 
-  test 'CarePlan search by patient',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
-
-    get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id})
-
-  end
-
-  test 'CarePlan search by category',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: category' do
-
-    todo
-  end
-
-  test 'CarePlan search by status',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: status' do
-
-    todo
-  end
-
-  test 'CarePlan search by date',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: date' do
-
-    todo
-  end
-
   test 'CarePlan search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category' do
+          'A server is capable of returning all of a patient’s Assessment and Plan of Treatment information using GET /CarePlan?patient=[id]&category=assess-plan' do
 
-    todo
+    reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan"})
+    @careplan_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+
   end
 
   test 'CarePlan search by patient + category + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category + date' do
+          'A server SHOULD be capable of returning a patient’s Assessment and Plan of Treatment information over a specified time period using GET /CarePlan?patient=[id]&category=assess-plan&date=[date]' do
 
-    todo
+    warning {
+      assert !(@careplan_hash.nil? || @careplan_hash.empty?), 'No CarePlan resource available'
+      date = @careplan_hash['period']['end']
+      assert date, "CarePlan period end not returned"
+      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan", date: date})
+      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+    }
+
   end
 
   test 'CarePlan search by patient + category + status',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category + status' do
+          'A server SHOULD be capable returning all of a patient’s active Assessment and Plan of Treatment information using GET /CarePlan?patient=[id]&category=assess-plan&status=active' do
 
-    todo
+    warning {
+      assert !(@careplan_hash.nil? || @careplan_hash.empty?), 'No CarePlan resource available'
+      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan", status: "active"})
+      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+    }
+
   end
 
   test 'CarePlan search by patient + category + status + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category + status + date' do
+          'A server SHOULD be capable returning a patient’s active Assessment and Plan of Treatment information over a specified time period using GET /CarePlan?patient=[id]&category=assess-plan&status=active&date=[date]' do
 
-    todo
+    warning {
+      assert !(@careplan_hash.nil? || @careplan_hash.empty?), 'No CarePlan resource available'
+      date = @careplan_hash['period']['end']
+      assert date, "CarePlan period end not returned"
+      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan", status: "active", date: date})
+      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+    }
+
   end
 
   # --------------------------------------------------
@@ -237,39 +189,72 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'Condition search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
+          'A server is capable of returning a patient’s conditions list using GET/Condition?patient=[id]' do
 
-    get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id})
-
+    reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id})
+    @condition_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::Condition, reply)
 
   end
 
-  test 'Condition search by category',
+  test 'Condition search by patient + active clinicalstatus',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: category' do
+          'A server SHOULD be capable returning all of a patient’s active problems and health concerns using ‘GET /Condition?patient=[id]&clinicalstatus=active,recurrance,remission' do
 
-    todo
+    warning {
+      assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
+      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, clinicalstatus: "active"})
+      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+    }
+
   end
 
-  test 'Condition search by clinicalstatus',
+  test 'Condition search by patient + recurrance clinicalstatus',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: clinicalstatus' do
+          'A server SHOULD be capable returning all of a patient’s active problems and health concerns using ‘GET /Condition?patient=[id]&clinicalstatus=active,recurrance,remission' do
 
-    todo
+    warning {
+      assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
+      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, clinicalstatus: "recurrance"})
+      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+    }
+
   end
 
-  test 'Condition search by patient + clinicalstatus',
+  test 'Condition search by patient + remission clinicalstatus',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + clinicalstatus' do
+          'A server SHOULD be capable returning all of a patient’s active problems and health concerns using ‘GET /Condition?patient=[id]&clinicalstatus=active,recurrance,remission' do
 
-    todo
+    warning {
+      assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
+      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, clinicalstatus: "remission"})
+      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+    }
+
   end
 
-  test 'Condition search by patient + category',
+  test 'Condition search by patient + problem category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category' do
+          'A server SHOULD be capable returning all of a patient’s problems or all of patient’s health concerns using ‘GET /Condition?patient=[id]&category=[problem|health-concern]' do
 
-    todo
+    warning {
+      assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
+      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "problem"})
+      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+    }
+
+  end
+
+  test 'Condition search by patient + health-concern category',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A server SHOULD be capable returning all of a patient’s problems or all of patient’s health concerns using ‘GET /Condition?patient=[id]&category=[problem|health-concern]' do
+
+    warning {
+      assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
+      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "health-concern"})
+      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+    }
+
   end
 
   # --------------------------------------------------
@@ -278,9 +263,11 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'Device search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
+          'A server is capable of returning all Unique device identifier(s)(UDI) for a patient’s implanted device(s) using GET /Device?patient=[id]' do
 
-    get_resource_by_params(FHIR::DSTU2::Device, {patient: @instance.patient_id})
+    reply = get_resource_by_params(FHIR::DSTU2::Device, {patient: @instance.patient_id})
+    @device_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::Device, reply)
 
   end
 
@@ -290,24 +277,24 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'Goal search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
+          'A server is capable of returning all of a patient’s goals using GET [base]/Goal?patient=[id]' do
 
-    get_resource_by_params(FHIR::DSTU2::Goal, {patient: @instance.patient_id})
+    reply = get_resource_by_params(FHIR::DSTU2::Goal, {patient: @instance.patient_id})
+    @goal_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::Goal, reply)
 
-  end
-
-  test 'Goal search by date',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: date' do
-
-    todo
   end
 
   test 'Goal search by patient + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + date' do
+          'A server is capable of returning all of all of a patient’s goals over a specified time period using GET [base]/Goal?patient=[id]&date=[date]{&date=[date]}' do
 
-    todo
+    assert !(@goal_hash.nil? || @goal_hash.empty?), 'No Goal resource available'
+    date = @goal_hash['statusDate']
+    assert date, "Goal statusDate not returned"
+    reply = get_resource_by_params(FHIR::DSTU2::Goal, {patient: @instance.patient_id, date: date})
+    validate_resource_by_params(FHIR::DSTU2::Goal, reply)
+
   end
 
   # --------------------------------------------------
@@ -316,9 +303,11 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'Immunization search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
+          'A client has connected to a server and fetched all immunizations for a patient using GET /Immunization?patient=[id]' do
 
-    get_resource_by_params(FHIR::DSTU2::Immunization, {patient: @instance.patient_id})
+    reply = get_resource_by_params(FHIR::DSTU2::Immunization, {patient: @instance.patient_id})
+    @immunization_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::Immunization, reply)
 
   end
 
@@ -326,66 +315,55 @@ class ArgonautSearchSequence < SequenceBase
   # DiagnosticReport Search
   # --------------------------------------------------
 
-  test 'DiagnosticReport search by patient',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
-
-    get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id})
-
-  end
-
-  test 'DiagnosticReport search by category',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: category' do
-
-    todo
-  end
-
-  test 'DiagnosticReport search by code',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: code' do
-
-    todo
-  end
-
-  test 'DiagnosticReport search by date',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: date' do
-
-    todo
-  end
-
   test 'DiagnosticReport search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category' do
+          'A server is capable of returning all of a patient’s laboratory diagnostic reports queried by category using GET [base]/DiagnosticReport?patient=[id]&category=LAB' do
 
-    todo
+    reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB"})
+    @diagnosticreport_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::DiagnosticReport, reply)
+
   end
 
   test 'DiagnosticReport search by patient + category + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category + date' do
+          'A server is capable of returning all of a patient’s laboratory diagnostic reports queried by category code and date range using GET [base]/DiagnosticReport?patient=[id]&category=LAB&date=[date]{&date=[date]}' do
 
-    todo
+    assert !(@diagnosticreport_hash.nil? || @diagnosticreport_hash.empty?), 'No DiagnosticReport resource available'
+    date = @diagnosticreport_hash['effectiveDateTime']
+    assert date, "DiagnosticReport effectiveDateTime not returned"
+    reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB", date: date})
+    validate_resource_by_params(FHIR::DSTU2::DiagnosticReport, reply)
+
   end
 
   test 'DiagnosticReport search by patient + category + code',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category + code' do
+          'A server is capable of returning all of a patient’s laboratory diagnostic reports queried by category and code using GET [base]/DiagnosticReport?patient=[id]&category=LAB&code=[LOINC]' do
 
-    todo
+    assert !(@diagnosticreport_hash.nil? || @diagnosticreport_hash.empty?), 'No DiagnosticReport resource available'
+    code = @diagnosticreport_hash['code']['coding'][0]['code']
+    assert code, "DiagnosticReport code not returned"
+    reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB", code: code})
+    validate_resource_by_params(FHIR::DSTU2::DiagnosticReport, reply)
+
   end
 
   test 'DiagnosticReport search by patient + category + code + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category + code + date' do
+          'A server SHOULD be capable of returning all of a patient’s laboratory diagnostic reports queried by category and one or more codes and date range using GET [base]/DiagnosticReport?patient=[id]&category=LAB&code=[LOINC1{,LOINC2,LOINC3,…}]&date=[date]{&date=[date]}' do
 
-    todo
+    warning {
+      assert !(@diagnosticreport_hash.nil? || @diagnosticreport_hash.empty?), 'No DiagnosticReport resource available'
+      code = @diagnosticreport_hash['code']['coding'][0]['code']
+      assert code, "DiagnosticReport code not returned"
+      date = @diagnosticreport_hash['effectiveDateTime']
+      assert date, "DiagnosticReport effectiveDateTime not returned"
+      reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB", code: code, date: date})
+      validate_resource_by_params(FHIR::DSTU2::DiagnosticReport, reply)
+    }
+
   end
-
-  # --------------------------------------------------
-  # Medication Search
-  # --------------------------------------------------
 
   # --------------------------------------------------
   # MedicationStatement Search
@@ -393,9 +371,11 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'MedicationStatement search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
+          'A server is capable of returning a patient’s medications using one of or both 1. GET /MedicationStatement?patient=[id] 2. GET /MedicationStatement?patient=[id]&_include=MedicationStatement:medication' do
 
-    get_resource_by_params(FHIR::DSTU2::MedicationStatement, {patient: @instance.patient_id})
+    reply = get_resource_by_params(FHIR::DSTU2::MedicationStatement, {patient: @instance.patient_id})
+    @medicationstatement_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::MedicationStatement, reply)
 
   end
 
@@ -405,9 +385,11 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'MedicationOrder search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
+          'A server is capable of returning a patient’s medications using one of or both 1. GET /MedicationOrder?patient=[id] 2. GET /MedicationOrder?patient=[id]&_include=MedicationOrder:medication' do
 
-    get_resource_by_params(FHIR::DSTU2::MedicationOrder, {patient: @instance.patient_id})
+    reply = get_resource_by_params(FHIR::DSTU2::MedicationOrder, {patient: @instance.patient_id})
+    @medicationorder_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::MedicationOrder, reply)
 
   end
 
@@ -415,61 +397,108 @@ class ArgonautSearchSequence < SequenceBase
   # Observation Search
   # --------------------------------------------------
 
-  test 'Observation search by patient',
+  test 'Observation Results search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
+          "A server is capable of returning all of a patient's laboratory results queried by category using GET [base]/Observation?patient=[id]&category=laboratory" do
 
-    get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id})
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory"})
+    @observationresults_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::Observation, reply)
 
   end
 
-  test 'Observation search by category',
+  test 'Observation Results search by patient + category + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: category' do
+          "A server is capable of returning all of a patient's laboratory results queried by category code and date range usingGET [base]/Observation?patient=[id]&category=laboratory&date=[date]{&date=[date]}" do
 
-    todo
+    assert !(@observationresults_hash.nil? || @observationresults_hash.empty?), 'No Observation resource available'
+    date = @observationresults_hash['effectiveDateTime']
+    assert date, "Observation effectiveDateTime not returned"
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory", date: date})
+
   end
 
-  test 'Observation search by code',
+  test 'Observation Results search by patient + category + code',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: code' do
+          "A server is capable of returning all of a patient's laboratory results queried by category and code using GET [base]/Observation?patient=[id]&category=laboratory&code=[LOINC]" do
 
-    todo
+    assert !(@observationresults_hash.nil? || @observationresults_hash.empty?), 'No Observation resource available'
+    code = @observationresults_hash['code']['coding'][0]['code']
+    assert code, "Observation code not returned"
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory", code: code})
+
   end
 
-  test 'Observation search by date',
+  test 'Observation Results search by patient + category + code + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: date' do
+          "A server SHOULD be capable of returning all of a patient's laboratory results queried by category and one or more codes and date range using GET [base]/Observation?patient=[id]&category=laboratory&code=[LOINC1{,LOINC2,LOINC3,...}]&date=[date]{&date=[date]}" do
 
-    todo
+    warning {
+      assert !(@observationresults_hash.nil? || @observationresults_hash.empty?), 'No Observation resource available'
+      code = @observationresults_hash['code']['coding'][0]['code']
+      assert code, "Observation code not returned"
+      date = @observationresults_hash['effectiveDateTime']
+      assert date, "Observation effectiveDateTime not returned"
+      reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory", code: code, date: date})
+    }
+
   end
 
-  test 'Observation search by patient + category',
+  test 'Smoking Status search by patient + code',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category' do
+          "A server is capable of returning a a patient’s smoking status using GET [base]/Observation?patient=[id]&code=72166-2" do
 
-    todo
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, code: "72166-2"})
+    @smokingstatus_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::Observation, reply)
+
   end
 
-  test 'Observation search by patient + category + date',
+  test 'Vital Signs search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category + date' do
+          "A server is capable of returning all of a patient’s vital signs that it supports using GET [base]/Observation?patient=[id]&category=vital-signs" do
 
-    todo
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs"})
+    @vitalsigns_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::Observation, reply)
+
   end
 
-  test 'Observation search by patient + category + code',
+  test 'Vital Signs search by patient + category + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category + code' do
+          "A server is capable of returning all of a patient’s vital signs queried by date range using GET [base]/Observation?patient=[id]&category=vital-signs&date=[date]{&date=[date]}" do
 
-    todo
+    assert !(@vitalsigns_hash.nil? || @vitalsigns_hash.empty?), 'No Observation resource available'
+    date = @vitalsigns_hash['effectiveDateTime']
+    assert date, "Observation effectiveDateTime not returned"
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs", date: date})
+
   end
 
-  test 'Observation search by patient + category + code + date',
+  test 'Vital Signs search by patient + category + code',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + category + code + date' do
+          "A server is capable of returning any of a patient’s vital signs queried by one or more of the codes listed below using GET [base]/Observation?patient=[id]&code[vital sign LOINC{,LOINC2,LOINC3,…}]" do
 
-    todo
+    assert !(@vitalsigns_hash.nil? || @vitalsigns_hash.empty?), 'No Observation resource available'
+    code = @vitalsigns_hash['code']['coding'][0]['code']
+    assert code, "Observation code not returned"
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs", code: code})
+
+  end
+
+  test 'Vital Signs search by patient + category + code + date',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          "A server SHOULD be capable of returning any of a patient’s vital signs queried by one or more of the codes listed below and date range using GET [base]/Observation?patient=[id]&code=[LOINC{,LOINC2…}]vital-signs&date=[date]{&date=[date]}" do
+
+    warning {
+      assert !(@vitalsigns_hash.nil? || @vitalsigns_hash.empty?), 'No Observation resource available'
+      code = @vitalsigns_hash['code']['coding'][0]['code']
+      assert code, "Observation code not returned"
+      date = @vitalsigns_hash['effectiveDateTime']
+      assert date, "Observation effectiveDateTime not returned"
+      reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs", code: code, date: date})
+    }
+
   end
 
   # --------------------------------------------------
@@ -478,24 +507,23 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'Procedure search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient' do
+          'A server is capable of returning a patient’s procedures using GET/Procedure?patient=[id]' do
 
-    get_resource_by_params(FHIR::DSTU2::Procedure, {patient: @instance.patient_id})
+    reply = get_resource_by_params(FHIR::DSTU2::Procedure, {patient: @instance.patient_id})
+    @procedure_hash = reply.resource.entry[0].resource.to_hash rescue []
+    validate_resource_by_params(FHIR::DSTU2::Procedure, reply)
 
-  end
-
-  test 'Procedure search by date',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: date' do
-
-    todo
   end
 
   test 'Procedure search by patient + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'Supported Searches: patient + date' do
+          'A server is capable of returning all of all of a patient’s procedures over a specified time period using GET /Procedure?patient=[id]&date=[date]{&date=[date]}' do
 
-    todo
+    assert !(@procedure_hash.nil? || @procedure_hash.empty?), 'No Procedure resource available'
+    date = @procedure_hash['performedDateTime']
+    assert date, "Procedure performedDateTime not returned"
+    reply = get_resource_by_params(FHIR::DSTU2::Procedure, {patient: @instance.patient_id, date: date})
+    validate_resource_by_params(FHIR::DSTU2::Procedure, reply)
   end
 
 end


### PR DESCRIPTION
Implements first pass at all search tests. These need to be tested and verified for accuracy.

Note that the sequence is currently prone to timeout, since the search tests take a significant amount of time to finish if a patient has many associated resources.

Note that currently all resources are tested, even though not all are required to be tested. There will need to be some form of handling so that only relevant supported resources are tested.