### PR TITLE
Search test bug fixes

### DIFF
--- a/lib/sequences/06_argonaut_search_sequence.rb
+++ b/lib/sequences/06_argonaut_search_sequence.rb
@@ -62,7 +62,7 @@ class ArgonautSearchSequence < SequenceBase
           'A server has exposed a FHIR Patient search endpoint supporting at a minimum the following search parameters: identifier' do
 
     assert !(@patient_hash.nil? || @patient_hash.empty?), 'No Patient resource available'
-    identifier = @patient_hash['identifier'][0]['value']
+    identifier = @patient_hash['identifier'][0]['value'] rescue nil
     assert identifier, "Patient identifier not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Patient, {identifier: identifier})
     validate_resource_by_params(FHIR::DSTU2::Patient, reply)
@@ -74,11 +74,11 @@ class ArgonautSearchSequence < SequenceBase
           'A server has exposed a FHIR Patient search endpoint supporting at a minimum the following search parameters when at least 2 (example name and gender) are present: name, gender, birthdate' do
 
     assert !(@patient_hash.nil? || @patient_hash.empty?), 'No Patient resource available'
-    family = @patient_hash['name'][0]['family'][0]
+    family = @patient_hash['name'][0]['family'][0] rescue nil
     assert family, "Patient family name not returned"
-    given = @patient_hash['name'][0]['given'][0]
+    given = @patient_hash['name'][0]['given'][0] rescue nil
     assert given, "Patient given name not returned"
-    gender = @patient_hash['gender']
+    gender = @patient_hash['gender'] rescue nil
     assert gender, "Patient gender not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, gender: gender})
     validate_resource_by_params(FHIR::DSTU2::Patient, reply)
@@ -90,11 +90,11 @@ class ArgonautSearchSequence < SequenceBase
           'A server has exposed a FHIR Patient search endpoint supporting at a minimum the following search parameters when at least 2 (example name and gender) are present: name, gender, birthdate' do
 
     assert !(@patient_hash.nil? || @patient_hash.empty?), 'No Patient resource available'
-    family = @patient_hash['name'][0]['family'][0]
+    family = @patient_hash['name'][0]['family'][0] rescue nil
     assert family, "Patient family name not returned"
-    given = @patient_hash['name'][0]['given'][0]
+    given = @patient_hash['name'][0]['given'][0] rescue nil
     assert given, "Patient given name not returned"
-    birthdate = @patient_hash['birthDate']
+    birthdate = @patient_hash['birthDate'] rescue nil
     assert birthdate, "Patient birthDate not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, birthdate: birthdate})
     validate_resource_by_params(FHIR::DSTU2::Patient, reply)
@@ -106,9 +106,9 @@ class ArgonautSearchSequence < SequenceBase
           'A server has exposed a FHIR Patient search endpoint supporting at a minimum the following search parameters when at least 2 (example name and gender) are present: name, gender, birthdate' do
 
     assert !(@patient_hash.nil? || @patient_hash.empty?), 'No Patient resource available'
-    gender = @patient_hash['gender']
+    gender = @patient_hash['gender'] rescue nil
     assert gender, "Patient gender not returned"
-    birthdate = @patient_hash['birthDate']
+    birthdate = @patient_hash['birthDate'] rescue nil
     assert birthdate, "Patient birthDate not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Patient, {gender: gender, birthdate: birthdate})
     validate_resource_by_params(FHIR::DSTU2::Patient, reply)
@@ -149,7 +149,7 @@ class ArgonautSearchSequence < SequenceBase
 
     warning {
       assert !(@careplan_hash.nil? || @careplan_hash.empty?), 'No CarePlan resource available'
-      date = @careplan_hash['period']['end']
+      date = @careplan_hash['period']['end'] rescue nil
       assert date, "CarePlan period end not returned"
       reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan", date: date})
       validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
@@ -175,7 +175,7 @@ class ArgonautSearchSequence < SequenceBase
 
     warning {
       assert !(@careplan_hash.nil? || @careplan_hash.empty?), 'No CarePlan resource available'
-      date = @careplan_hash['period']['end']
+      date = @careplan_hash['period']['end'] rescue nil
       assert date, "CarePlan period end not returned"
       reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan", status: "active", date: date})
       validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
@@ -197,38 +197,14 @@ class ArgonautSearchSequence < SequenceBase
 
   end
 
-  test 'Condition search by patient + active clinicalstatus',
+  test 'Condition search by patient + clinicalstatus',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'A server SHOULD be capable returning all of a patient’s active problems and health concerns using ‘GET /Condition?patient=[id]&clinicalstatus=active,recurrance,remission' do
 
     warning {
       assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
-      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, clinicalstatus: "active"})
-      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
-    }
-
-  end
-
-  test 'Condition search by patient + recurrance clinicalstatus',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'A server SHOULD be capable returning all of a patient’s active problems and health concerns using ‘GET /Condition?patient=[id]&clinicalstatus=active,recurrance,remission' do
-
-    warning {
-      assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
-      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, clinicalstatus: "recurrance"})
-      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
-    }
-
-  end
-
-  test 'Condition search by patient + remission clinicalstatus',
-          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'A server SHOULD be capable returning all of a patient’s active problems and health concerns using ‘GET /Condition?patient=[id]&clinicalstatus=active,recurrance,remission' do
-
-    warning {
-      assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
-      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, clinicalstatus: "remission"})
-      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+      reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id, clinicalstatus: "active,recurrance,remission"})
+      validate_resource_by_params(FHIR::DSTU2::Condition, reply)
     }
 
   end
@@ -239,8 +215,8 @@ class ArgonautSearchSequence < SequenceBase
 
     warning {
       assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
-      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "problem"})
-      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+      reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id, category: "problem"})
+      validate_resource_by_params(FHIR::DSTU2::Condition, reply)
     }
 
   end
@@ -251,8 +227,8 @@ class ArgonautSearchSequence < SequenceBase
 
     warning {
       assert !(@condition_hash.nil? || @condition_hash.empty?), 'No Condition resource available'
-      reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "health-concern"})
-      validate_resource_by_params(FHIR::DSTU2::CarePlan, reply)
+      reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id, category: "health-concern"})
+      validate_resource_by_params(FHIR::DSTU2::Condition, reply)
     }
 
   end
@@ -290,7 +266,7 @@ class ArgonautSearchSequence < SequenceBase
           'A server is capable of returning all of all of a patient’s goals over a specified time period using GET [base]/Goal?patient=[id]&date=[date]{&date=[date]}' do
 
     assert !(@goal_hash.nil? || @goal_hash.empty?), 'No Goal resource available'
-    date = @goal_hash['statusDate']
+    date = @goal_hash['statusDate'] rescue nil
     assert date, "Goal statusDate not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Goal, {patient: @instance.patient_id, date: date})
     validate_resource_by_params(FHIR::DSTU2::Goal, reply)
@@ -330,7 +306,7 @@ class ArgonautSearchSequence < SequenceBase
           'A server is capable of returning all of a patient’s laboratory diagnostic reports queried by category code and date range using GET [base]/DiagnosticReport?patient=[id]&category=LAB&date=[date]{&date=[date]}' do
 
     assert !(@diagnosticreport_hash.nil? || @diagnosticreport_hash.empty?), 'No DiagnosticReport resource available'
-    date = @diagnosticreport_hash['effectiveDateTime']
+    date = @diagnosticreport_hash['effectiveDateTime'] rescue nil
     assert date, "DiagnosticReport effectiveDateTime not returned"
     reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB", date: date})
     validate_resource_by_params(FHIR::DSTU2::DiagnosticReport, reply)
@@ -342,7 +318,7 @@ class ArgonautSearchSequence < SequenceBase
           'A server is capable of returning all of a patient’s laboratory diagnostic reports queried by category and code using GET [base]/DiagnosticReport?patient=[id]&category=LAB&code=[LOINC]' do
 
     assert !(@diagnosticreport_hash.nil? || @diagnosticreport_hash.empty?), 'No DiagnosticReport resource available'
-    code = @diagnosticreport_hash['code']['coding'][0]['code']
+    code = @diagnosticreport_hash['code']['text'] rescue nil
     assert code, "DiagnosticReport code not returned"
     reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB", code: code})
     validate_resource_by_params(FHIR::DSTU2::DiagnosticReport, reply)
@@ -355,7 +331,7 @@ class ArgonautSearchSequence < SequenceBase
 
     warning {
       assert !(@diagnosticreport_hash.nil? || @diagnosticreport_hash.empty?), 'No DiagnosticReport resource available'
-      code = @diagnosticreport_hash['code']['coding'][0]['code']
+      code = @diagnosticreport_hash['code']['text'] rescue nil
       assert code, "DiagnosticReport code not returned"
       date = @diagnosticreport_hash['effectiveDateTime']
       assert date, "DiagnosticReport effectiveDateTime not returned"
@@ -412,9 +388,10 @@ class ArgonautSearchSequence < SequenceBase
           "A server is capable of returning all of a patient's laboratory results queried by category code and date range usingGET [base]/Observation?patient=[id]&category=laboratory&date=[date]{&date=[date]}" do
 
     assert !(@observationresults_hash.nil? || @observationresults_hash.empty?), 'No Observation resource available'
-    date = @observationresults_hash['effectiveDateTime']
+    date = @observationresults_hash['effectiveDateTime'] rescue nil
     assert date, "Observation effectiveDateTime not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory", date: date})
+    validate_resource_by_params(FHIR::DSTU2::Observation, reply)
 
   end
 
@@ -423,9 +400,10 @@ class ArgonautSearchSequence < SequenceBase
           "A server is capable of returning all of a patient's laboratory results queried by category and code using GET [base]/Observation?patient=[id]&category=laboratory&code=[LOINC]" do
 
     assert !(@observationresults_hash.nil? || @observationresults_hash.empty?), 'No Observation resource available'
-    code = @observationresults_hash['code']['coding'][0]['code']
+    code = @observationresults_hash['code']['coding'][0]['code'] rescue nil
     assert code, "Observation code not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory", code: code})
+    validate_resource_by_params(FHIR::DSTU2::Observation, reply)
 
   end
 
@@ -435,11 +413,12 @@ class ArgonautSearchSequence < SequenceBase
 
     warning {
       assert !(@observationresults_hash.nil? || @observationresults_hash.empty?), 'No Observation resource available'
-      code = @observationresults_hash['code']['coding'][0]['code']
+      code = @observationresults_hash['code']['coding'][0]['code'] rescue nil
       assert code, "Observation code not returned"
-      date = @observationresults_hash['effectiveDateTime']
+      date = @observationresults_hash['effectiveDateTime'] rescue nil
       assert date, "Observation effectiveDateTime not returned"
       reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory", code: code, date: date})
+      validate_resource_by_params(FHIR::DSTU2::Observation, reply)
     }
 
   end
@@ -469,9 +448,10 @@ class ArgonautSearchSequence < SequenceBase
           "A server is capable of returning all of a patient’s vital signs queried by date range using GET [base]/Observation?patient=[id]&category=vital-signs&date=[date]{&date=[date]}" do
 
     assert !(@vitalsigns_hash.nil? || @vitalsigns_hash.empty?), 'No Observation resource available'
-    date = @vitalsigns_hash['effectiveDateTime']
+    date = @vitalsigns_hash['effectiveDateTime'] rescue nil
     assert date, "Observation effectiveDateTime not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs", date: date})
+    validate_resource_by_params(FHIR::DSTU2::Observation, reply)
 
   end
 
@@ -480,9 +460,10 @@ class ArgonautSearchSequence < SequenceBase
           "A server is capable of returning any of a patient’s vital signs queried by one or more of the codes listed below using GET [base]/Observation?patient=[id]&code[vital sign LOINC{,LOINC2,LOINC3,…}]" do
 
     assert !(@vitalsigns_hash.nil? || @vitalsigns_hash.empty?), 'No Observation resource available'
-    code = @vitalsigns_hash['code']['coding'][0]['code']
+    code = @vitalsigns_hash['code']['coding'][0]['code'] rescue nil
     assert code, "Observation code not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs", code: code})
+    validate_resource_by_params(FHIR::DSTU2::Observation, reply)
 
   end
 
@@ -492,11 +473,12 @@ class ArgonautSearchSequence < SequenceBase
 
     warning {
       assert !(@vitalsigns_hash.nil? || @vitalsigns_hash.empty?), 'No Observation resource available'
-      code = @vitalsigns_hash['code']['coding'][0]['code']
+      code = @vitalsigns_hash['code']['coding'][0]['code'] rescue nil
       assert code, "Observation code not returned"
       date = @vitalsigns_hash['effectiveDateTime']
       assert date, "Observation effectiveDateTime not returned"
       reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs", code: code, date: date})
+      validate_resource_by_params(FHIR::DSTU2::Observation, reply)
     }
 
   end
@@ -520,7 +502,7 @@ class ArgonautSearchSequence < SequenceBase
           'A server is capable of returning all of all of a patient’s procedures over a specified time period using GET /Procedure?patient=[id]&date=[date]{&date=[date]}' do
 
     assert !(@procedure_hash.nil? || @procedure_hash.empty?), 'No Procedure resource available'
-    date = @procedure_hash['performedDateTime']
+    date = @procedure_hash['performedDateTime'] rescue nil
     assert date, "Procedure performedDateTime not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Procedure, {patient: @instance.patient_id, date: date})
     validate_resource_by_params(FHIR::DSTU2::Procedure, reply)


### PR DESCRIPTION
There were a few typos and mistakes in the search test sequence causing certain patients to throw errors on some tests. This PR fixes typos and adds more handling to prevent errors.