### PR TITLE
Implement no-auth search tests and additional patient tests

### DIFF
--- a/lib/sequences/06_argonaut_profiles_sequence.rb
+++ b/lib/sequences/06_argonaut_profiles_sequence.rb
@@ -30,21 +30,23 @@ class ArgonautProfilesSequence < SequenceBase
   end
 
   test 'Patient has address',
+          nil,
           'Additional Patient resource requirement' do
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
     assert @patient.is_a?(FHIR::DSTU2::Patient), 'Expected resource to be valid DSTU2 Patient'
-    telecom = @patient.try(:address).try(:first)
-    assert telecom, 'Patient address not returned'
+    address = @patient.try(:address).try(:first)
+    assert !address.nil?, 'Patient address not returned'
   end
 
   test 'Patient has telecom',
+          nil,
           'Additional Patient resource requirement' do
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
     assert @patient.is_a?(FHIR::DSTU2::Patient), 'Expected resource to be valid DSTU2 Patient'
     telecom = @patient.try(:telecom).try(:first)
-    assert telecom, 'Patient telecom not returned'
+    assert !telecom.nil?, 'Patient telecom not returned'
   end
 
   test 'Patient supports $everything operation', '' do

--- a/lib/sequences/06_argonaut_profiles_sequence.rb
+++ b/lib/sequences/06_argonaut_profiles_sequence.rb
@@ -19,7 +19,6 @@ class ArgonautProfilesSequence < SequenceBase
     assert_response_ok patient_read_response
     @patient = patient_read_response.resource
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
-    @patient_details = @patient.to_hash
     assert @patient.is_a?(FHIR::DSTU2::Patient), 'Expected resource to be valid DSTU2 Patient'
   end
 
@@ -28,6 +27,24 @@ class ArgonautProfilesSequence < SequenceBase
     profile = ValidationUtil.guess_profile(@patient)
     errors = profile.validate_resource(@patient)
     assert errors.empty?, "Patient did not validate against profile: #{errors.join(", ")}"
+  end
+
+  test 'Patient has address',
+          'Additional Patient resource requirement' do
+
+    assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
+    assert @patient.is_a?(FHIR::DSTU2::Patient), 'Expected resource to be valid DSTU2 Patient'
+    telecom = @patient.try(:address).try(:first)
+    assert telecom, 'Patient address not returned'
+  end
+
+  test 'Patient has telecom',
+          'Additional Patient resource requirement' do
+
+    assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
+    assert @patient.is_a?(FHIR::DSTU2::Patient), 'Expected resource to be valid DSTU2 Patient'
+    telecom = @patient.try(:telecom).try(:first)
+    assert telecom, 'Patient telecom not returned'
   end
 
   test 'Patient supports $everything operation', '' do

--- a/lib/sequences/07_argonaut_search_sequence.rb
+++ b/lib/sequences/07_argonaut_search_sequence.rb
@@ -64,7 +64,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
     identifier = @patient.try(:identifier).try(:first).try(:value)
-    assert identifier, "Patient identifier not returned"
+    assert !identifier.nil?, "Patient identifier not returned"
     @client.set_no_auth
     reply = get_resource_by_params(FHIR::DSTU2::Patient, {identifier: identifier})
     @client.set_bearer_token(@instance.token)
@@ -78,7 +78,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
     identifier = @patient.try(:identifier).try(:first).try(:value)
-    assert identifier, "Patient identifier not returned"
+    assert !identifier.nil?, "Patient identifier not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Patient, {identifier: identifier})
     validate_reply(FHIR::DSTU2::Patient, reply)
 
@@ -90,11 +90,11 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
     family = @patient.try(:name).try(:first).try(:family).try(:first)
-    assert family, "Patient family name not returned"
+    assert !family.nil?, "Patient family name not returned"
     given = @patient.try(:name).try(:first).try(:given).try(:first)
-    assert given, "Patient given name not returned"
+    assert !given.nil?, "Patient given name not returned"
     gender = @patient.try(:gender)
-    assert gender, "Patient gender not returned"
+    assert !gender.nil?, "Patient gender not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, gender: gender})
     validate_reply(FHIR::DSTU2::Patient, reply)
 
@@ -106,11 +106,11 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
     family = @patient.try(:name).try(:first).try(:family).try(:first)
-    assert family, "Patient family name not returned"
+    assert !family.nil?, "Patient family name not returned"
     given = @patient.try(:name).try(:first).try(:given).try(:first)
-    assert given, "Patient given name not returned"
+    assert !given.nil?, "Patient given name not returned"
     birthdate = @patient.try(:birthDate)
-    assert birthdate, "Patient birthDate not returned"
+    assert !birthdate.nil?, "Patient birthDate not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Patient, {family: family, given: given, birthdate: birthdate})
     validate_reply(FHIR::DSTU2::Patient, reply)
 
@@ -122,9 +122,9 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
     gender = @patient.try(:gender)
-    assert gender, "Patient gender not returned"
+    assert !gender.nil?, "Patient gender not returned"
     birthdate = @patient.try(:birthDate)
-    assert birthdate, "Patient birthDate not returned"
+    assert !birthdate.nil?, "Patient birthDate not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Patient, {gender: gender, birthdate: birthdate})
     validate_reply(FHIR::DSTU2::Patient, reply)
 
@@ -186,7 +186,7 @@ class ArgonautSearchSequence < SequenceBase
     warning {
       assert !@careplan.nil?, 'Expected valid DSTU2 CarePlan resource to be present'
       date = @careplan.try(:period).try(:end)
-      assert date, "CarePlan period end not returned"
+      assert !date.nil?, "CarePlan period end not returned"
       reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan", date: date})
       validate_reply(FHIR::DSTU2::CarePlan, reply)
     }
@@ -211,7 +211,7 @@ class ArgonautSearchSequence < SequenceBase
     warning {
       assert !@careplan.nil?, 'Expected valid DSTU2 CarePlan resource to be present'
       date = @careplan.try(:period).try(:end)
-      assert date, "CarePlan period end not returned"
+      assert !date.nil?, "CarePlan period end not returned"
       reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan", status: "active", date: date})
       validate_reply(FHIR::DSTU2::CarePlan, reply)
     }
@@ -330,7 +330,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@goal.nil?, 'Expected valid DSTU2 Goal resource to be present'
     date = @goal.try(:statusDate)
-    assert date, "Goal statusDate not returned"
+    assert !date.nil?, "Goal statusDate not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Goal, {patient: @instance.patient_id, date: date})
     validate_reply(FHIR::DSTU2::Goal, reply)
 
@@ -391,7 +391,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@diagnosticreport.nil?, 'Expected valid DSTU2 DiagnosticReport resource to be present'
     date = @diagnosticreport.try(:effectiveDateTime)
-    assert date, "DiagnosticReport effectiveDateTime not returned"
+    assert !date.nil?, "DiagnosticReport effectiveDateTime not returned"
     reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB", date: date})
     validate_reply(FHIR::DSTU2::DiagnosticReport, reply)
 
@@ -403,7 +403,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@diagnosticreport.nil?, 'Expected valid DSTU2 DiagnosticReport resource to be present'
     code = @diagnosticreport.try(:code).try(:text)
-    assert code, "DiagnosticReport code not returned"
+    assert !code.nil?, "DiagnosticReport code not returned"
     reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB", code: code})
     validate_reply(FHIR::DSTU2::DiagnosticReport, reply)
 
@@ -416,9 +416,9 @@ class ArgonautSearchSequence < SequenceBase
     warning {
       assert !@diagnosticreport.nil?, 'Expected valid DSTU2 DiagnosticReport resource to be present'
       code = @diagnosticreport.try(:code).try(:text)
-      assert code, "DiagnosticReport code not returned"
+      assert !code.nil?, "DiagnosticReport code not returned"
       date = @diagnosticreport.try(:effectiveDateTime)
-      assert date, "DiagnosticReport effectiveDateTime not returned"
+      assert !date.nil?, "DiagnosticReport effectiveDateTime not returned"
       reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB", code: code, date: date})
       validate_reply(FHIR::DSTU2::DiagnosticReport, reply)
     }
@@ -504,7 +504,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@observationresults.nil?, 'Expected valid DSTU2 Observation resource to be present'
     date = @observationresults.try(:effectiveDateTime)
-    assert date, "Observation effectiveDateTime not returned"
+    assert !date.nil?, "Observation effectiveDateTime not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory", date: date})
     validate_reply(FHIR::DSTU2::Observation, reply)
 
@@ -516,7 +516,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@observationresults.nil?, 'Expected valid DSTU2 Observation resource to be present'
     code = @observationresults.try(:code).try(:coding).try(:first).try(:code)
-    assert code, "Observation code not returned"
+    assert !code.nil?, "Observation code not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory", code: code})
     validate_reply(FHIR::DSTU2::Observation, reply)
 
@@ -529,9 +529,9 @@ class ArgonautSearchSequence < SequenceBase
     warning {
       assert !@observationresults.nil?, 'Expected valid DSTU2 Observation resource to be present'
       code = @observationresults.try(:code).try(:coding).try(:first).try(:code)
-      assert code, "Observation code not returned"
+      assert !code.nil?, "Observation code not returned"
       date = @observationresults.try(:effectiveDateTime)
-      assert date, "Observation effectiveDateTime not returned"
+      assert !date.nil?, "Observation effectiveDateTime not returned"
       reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory", code: code, date: date})
       validate_reply(FHIR::DSTU2::Observation, reply)
     }
@@ -585,7 +585,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@vitalsigns.nil?, 'Expected valid DSTU2 Observation resource to be present'
     date = @vitalsigns.try(:effectiveDateTime)
-    assert date, "Observation effectiveDateTime not returned"
+    assert !date.nil?, "Observation effectiveDateTime not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs", date: date})
     validate_reply(FHIR::DSTU2::Observation, reply)
 
@@ -597,7 +597,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@vitalsigns.nil?, 'Expected valid DSTU2 Observation resource to be present'
     code = @vitalsigns.try(:code).try(:coding).try(:first).try(:code)
-    assert code, "Observation code not returned"
+    assert !code.nil?, "Observation code not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs", code: code})
     validate_reply(FHIR::DSTU2::Observation, reply)
 
@@ -610,9 +610,9 @@ class ArgonautSearchSequence < SequenceBase
     warning {
       assert !@vitalsigns.nil?, 'Expected valid DSTU2 Observation resource to be present'
       code = @vitalsigns.try(:code).try(:coding).try(:first).try(:code)
-      assert code, "Observation code not returned"
+      assert !code.nil?, "Observation code not returned"
       date = @vitalsigns.try(:effectiveDateTime)
-      assert date, "Observation effectiveDateTime not returned"
+      assert !date.nil?, "Observation effectiveDateTime not returned"
       reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs", code: code, date: date})
       validate_reply(FHIR::DSTU2::Observation, reply)
     }
@@ -650,7 +650,7 @@ class ArgonautSearchSequence < SequenceBase
 
     assert !@procedure.nil?, 'Expected valid DSTU2 Procedure resource to be present'
     date = @procedure.try(:performedDateTime)
-    assert date, "Procedure performedDateTime not returned"
+    assert !date.nil?, "Procedure performedDateTime not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Procedure, {patient: @instance.patient_id, date: date})
     validate_reply(FHIR::DSTU2::Procedure, reply)
 

--- a/lib/sequences/07_argonaut_search_sequence.rb
+++ b/lib/sequences/07_argonaut_search_sequence.rb
@@ -59,6 +59,20 @@ class ArgonautSearchSequence < SequenceBase
 
   end
 
+  test 'Patient search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A Patient search does not work without proper authorization' do
+
+    assert !(@patient_hash.nil? || @patient_hash.empty?), 'No Patient resource available'
+    identifier = @patient_hash['identifier'][0]['value'] rescue nil
+    assert identifier, "Patient identifier not returned"
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::Patient, {identifier: identifier})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
+
   test 'Patient search by identifier',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'A server has exposed a FHIR Patient search endpoint supporting at a minimum the following search parameters: identifier' do
@@ -121,6 +135,17 @@ class ArgonautSearchSequence < SequenceBase
   # AllergyIntolerance Search
   # --------------------------------------------------
 
+  test 'AllergyIntolerance search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'An AllergyIntolerance search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::AllergyIntolerance, {patient: @instance.patient_id})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
+
   test 'AllergyIntolerance search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'A server is capable of returning a patient’s allergies using GET /AllergyIntolerance?patient=[id]' do
@@ -134,6 +159,17 @@ class ArgonautSearchSequence < SequenceBase
   # --------------------------------------------------
   # CarePlan Search
   # --------------------------------------------------
+
+  test 'CarePlan search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A CarePlan search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::CarePlan, {patient: @instance.patient_id, category: "assess-plan"})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
 
   test 'CarePlan search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
@@ -189,6 +225,17 @@ class ArgonautSearchSequence < SequenceBase
   # Condition Search
   # --------------------------------------------------
 
+  test 'Condition search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A Condition search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
+
   test 'Condition search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'A server is capable of returning a patient’s conditions list using GET/Condition?patient=[id]' do
@@ -239,6 +286,17 @@ class ArgonautSearchSequence < SequenceBase
   # Device Search
   # --------------------------------------------------
 
+  test 'Device search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A Device search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::Device, {patient: @instance.patient_id})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
+
   test 'Device search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'A server is capable of returning all Unique device identifier(s)(UDI) for a patient’s implanted device(s) using GET /Device?patient=[id]' do
@@ -252,6 +310,17 @@ class ArgonautSearchSequence < SequenceBase
   # --------------------------------------------------
   # Goal Search
   # --------------------------------------------------
+
+  test 'Goal search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A Goal search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::Goal, {patient: @instance.patient_id})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
 
   test 'Goal search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
@@ -279,6 +348,17 @@ class ArgonautSearchSequence < SequenceBase
   # Immunization Search
   # --------------------------------------------------
 
+  test 'Immunization search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'An Immunization search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::Immunization, {patient: @instance.patient_id})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
+
   test 'Immunization search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'A client has connected to a server and fetched all immunizations for a patient using GET /Immunization?patient=[id]' do
@@ -292,6 +372,17 @@ class ArgonautSearchSequence < SequenceBase
   # --------------------------------------------------
   # DiagnosticReport Search
   # --------------------------------------------------
+
+  test 'DiagnosticReport search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A DiagnosticReport search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::DiagnosticReport, {patient: @instance.patient_id, category: "LAB"})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
 
   test 'DiagnosticReport search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
@@ -347,6 +438,17 @@ class ArgonautSearchSequence < SequenceBase
   # MedicationStatement Search
   # --------------------------------------------------
 
+  test 'MedicationStatement search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'An MedicationStatement search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::MedicationStatement, {patient: @instance.patient_id})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
+
   test 'MedicationStatement search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'A server is capable of returning a patient’s medications using one of or both 1. GET /MedicationStatement?patient=[id] 2. GET /MedicationStatement?patient=[id]&_include=MedicationStatement:medication' do
@@ -361,6 +463,17 @@ class ArgonautSearchSequence < SequenceBase
   # MedicationOrder Search
   # --------------------------------------------------
 
+  test 'MedicationOrder search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'An MedicationOrder search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::MedicationOrder, {patient: @instance.patient_id})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
+
   test 'MedicationOrder search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           'A server is capable of returning a patient’s medications using one of or both 1. GET /MedicationOrder?patient=[id] 2. GET /MedicationOrder?patient=[id]&_include=MedicationOrder:medication' do
@@ -374,6 +487,17 @@ class ArgonautSearchSequence < SequenceBase
   # --------------------------------------------------
   # Observation Search
   # --------------------------------------------------
+
+  test 'Observation Results search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'An Observation Results search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "laboratory"})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
 
   test 'Observation Results search by patient + category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
@@ -425,6 +549,17 @@ class ArgonautSearchSequence < SequenceBase
 
   end
 
+  test 'Smoking Status search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A Smoking Status search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, code: "72166-2"})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
+
   test 'Smoking Status search by patient + code',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
           "A server is capable of returning a a patient’s smoking status using GET [base]/Observation?patient=[id]&code=72166-2" do
@@ -432,6 +567,17 @@ class ArgonautSearchSequence < SequenceBase
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, code: "72166-2"})
     @smokingstatus_hash = reply.resource.entry[0].resource.to_hash rescue []
     validate_reply(FHIR::DSTU2::Observation, reply)
+
+  end
+
+  test 'Vital Signs search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A Vital Signs search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, category: "vital-signs"})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
 
   end
 
@@ -488,6 +634,17 @@ class ArgonautSearchSequence < SequenceBase
   # --------------------------------------------------
   # Procedure Search
   # --------------------------------------------------
+
+  test 'Procedure search without authorization',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A Procedure search does not work without proper authorization' do
+
+    @client.set_no_auth
+    reply = get_resource_by_params(FHIR::DSTU2::Procedure, {patient: @instance.patient_id})
+    @client.set_bearer_token(@instance.token)
+    assert_response_unauthorized reply
+
+  end
 
   test 'Procedure search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',

--- a/lib/utils/assertions.rb
+++ b/lib/utils/assertions.rb
@@ -108,6 +108,12 @@ module Assertions
     end
   end
 
+  def assert_response_unauthorized(response)
+    unless assertion_negated( [401, 406].include?(response.code) )
+      raise AssertionException.new "Bad response code: expected 401 or 406, but found #{response.code}", response.body
+    end
+  end
+
   def assert_response_bad(response)
     unless assertion_negated( [400].include?(response.code) )
       raise AssertionException.new "Bad response code: expected 400, but found #{response.code}", response.body


### PR DESCRIPTION
This PR implements search tests without authorization for all resources, to verify that these searches fail (resolves #64). There is additional refactoring of search tests as well. This PR also adds Patient resource tests for address and telecom.