### PR TITLE
Print tests task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,10 @@ task :default do
   Rake::Task['test'].invoke
 end
 
+Dir['lib/tasks/*.rake'].sort.each do |ext|
+  load ext
+end
+
 Rake::TestTask.new(:default) do |t|
   t.libs << "test"
   t.pattern = 'test/**/*_test.rb'

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -2,6 +2,7 @@ require 'fhir_client'
 require 'pry'
 require './lib/sequence_base'
 require 'dm-core'
+require 'csv'
 
 ['lib', 'models'].each do |dir|
   Dir.glob(File.join(File.expand_path('../..', File.dirname(File.absolute_path(__FILE__))),dir, '**','*.rb')).each do |file|
@@ -10,17 +11,23 @@ require 'dm-core'
 end
 
 desc 'Generate List of All Tests'
-task :all_tests do
+task :tests_to_csv do
 
-  out = SequenceBase.subclasses.map do |klass|
+  flat_tests = SequenceBase.subclasses.map do |klass|
     klass.tests.map do |test|
       test[:sequence] = klass.to_s
       test
     end
   end.flatten.sort_by { |t| t[:test_index] }
 
-  puts = 'Sequence\tName\tDescription\tUrl"\n'
-  puts out.map { |test| "#{test[:sequence]}\t#{test[:name]}\t#{test[:description]}\t#{test[:url]}" }.join("\n")
+  csv_out = CSV.generate do |csv|
+    csv << ['Sequence', 'Name', 'Description', 'Url']
+    flat_tests.each do |test|
+      csv <<  [ test[:sequence], test[:name], test[:description], test[:url] ]
+    end
+  end
+
+  puts csv_out
 
 end
 

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -1,0 +1,26 @@
+require 'fhir_client'
+require 'pry'
+require './lib/sequence_base'
+require 'dm-core'
+
+['lib', 'models'].each do |dir|
+  Dir.glob(File.join(File.expand_path('../..', File.dirname(File.absolute_path(__FILE__))),dir, '**','*.rb')).each do |file|
+    require file
+  end
+end
+
+desc 'Generate List of All Tests'
+task :all_tests do
+
+  out = SequenceBase.subclasses.map do |klass|
+    klass.tests.map do |test|
+      test[:sequence] = klass.to_s
+      test
+    end
+  end.flatten.sort_by { |t| t[:test_index] }
+
+  puts = 'Sequence\tName\tDescription\tUrl"\n'
+  puts out.map { |test| "#{test[:sequence]}\t#{test[:name]}\t#{test[:description]}\t#{test[:url]}" }.join("\n")
+
+end
+


### PR DESCRIPTION
Rake task to print out tests and metadata to csv.

```bundle exec rake tests_to_csv```

I didn't bother saving to a file.  Seems easier to just let the use redirect to a file instead.  

```bundle exec rake tests_to_csv >> tests.csv```