### PR TITLE
Test metadata

### DIFF
--- a/lib/sequence_base.rb
+++ b/lib/sequence_base.rb
@@ -287,7 +287,7 @@ class SequenceBase
         ProviderEHRLaunchSequence, 
         TokenIntrospectionSequence, 
         ArgonautProfilesSequence, 
-        ArgonautSearchSequence,
+        ArgonautDataQuerySequence,
         AdditionalResourcesSequence]
   end
 

--- a/lib/sequence_base.rb
+++ b/lib/sequence_base.rb
@@ -22,14 +22,6 @@ class SequenceBase
   @@modal_before_run = []
   @@buttonless = []
 
-  def self.test_count
-    self.new(nil,nil).test_count
-  end
-
-  def test_count
-    self.methods.grep(/_test$/).length
-  end
-
   def initialize(instance, client, sequence_result = nil)
     @client = client
     @instance = instance
@@ -140,6 +132,15 @@ class SequenceBase
     @sequence_result
   end
 
+  def self.test_count
+    self.new(nil,nil).test_count
+  end
+
+  def test_count
+    self.methods.grep(/_test$/).length
+  end
+
+
   def sequence_name
     self.class.sequence_name
   end
@@ -197,33 +198,36 @@ class SequenceBase
     self.new(instance,nil).instance_eval &block
   end
 
-  def self.test(name, url = nil, description = nil, &block)
+  def self.test(name, url = nil, description = nil, required = :required, &block)
+
     @@test_index += 1
+
+    is_required = (required != :optional)
 
     test_index = @@test_index
     test_method = "#{@@test_index.to_s.rjust(4,"0")} #{name} test".downcase.tr(' ', '_').to_sym
     contents = block
 
     @@test_metadata[self.sequence_name] ||= [] 
-    @@test_metadata[self.sequence_name] << { name: name, url: url, description: description, test_index: test_index}
+    @@test_metadata[self.sequence_name] << { name: name, url: url, description: description, test_index: test_index, required: is_required}
 
     wrapped = -> () do
       @test_warnings, @links, @requires, @validates = [],[],[],[]
-      result = TestResult.new(name: name, result: STATUS[:pass], url: url, description: description, test_index: test_index)
+      result = TestResult.new(name: name, result: STATUS[:pass], url: url, description: description, test_index: test_index, required: is_required)
       begin
-        instance_eval &block
 
-        # result.update(t.status, t.message, t.data) if !t.nil? && t.is_a?(Crucible::Tests::TestResult)
-      rescue AssertionException => e
-        result.result = STATUS[:fail]
-        result.message = e.message
+      instance_eval &block
+
+      rescue AssertionException, ClientException => e
+        if required == :optional
+          @test_warnings << e.message
+        else
+          result.result = STATUS[:fail]
+          result.message = e.message
+        end
 
       rescue TodoException => e
         result.result = STATUS[:todo]
-        result.message = e.message
-
-      rescue ClientException => e
-        result.result = STATUS[:fail]
         result.message = e.message
 
       rescue WaitException => e
@@ -240,7 +244,6 @@ class SequenceBase
         result.message = e.message
 
       rescue => e
-        # binding.pry
         result.result = STATUS[:error]
         result.message = "Fatal Error: #{e.message}"
       end
@@ -274,5 +277,19 @@ class SequenceBase
       @test_warnings << e.message
     end
   end
+
+  # This is intended to be called on SequenceBase
+  # There is a test to ensure that this doesn't fall out of date
+  def self.ordered_sequences
+    [ ConformanceSequence, 
+        DynamicRegistrationSequence, 
+        PatientStandaloneLaunchSequence, 
+        ProviderEHRLaunchSequence, 
+        TokenIntrospectionSequence, 
+        ArgonautProfilesSequence, 
+        ArgonautSearchSequence,
+        AdditionalResourcesSequence]
+  end
+
 end
 

--- a/lib/sequences/01_conformance_sequence.rb
+++ b/lib/sequences/01_conformance_sequence.rb
@@ -2,23 +2,27 @@ class ConformanceSequence < SequenceBase
 
   title 'Conformance Statement'
 
-  description 'The FHIR server properly exposes a capability statement with necessary information.'
+  description 'The FHIR server exposes a Conformance Statement with the necessary information.'
 
   test 'Responds to metadata endpoint with DSTU2 Conformance resource',
-          'https://documentationlocation',
-          'Exact Language' do
+          'https://www.hl7.org/fhir/DSTU2/http.html',
+          'Servers SHALL provide a conformance statement that specifies which interactions and resources are supported.' do
 
     @conformance = @client.conformance_statement(FHIR::Formats::ResourceFormat::RESOURCE_JSON_DSTU2)
     assert_response_ok @client.reply
-    assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
+    assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource.'
   end
 
-  test 'Conformance states json support' do
+  test 'Conformance states json support',
+         'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+         'The Argonaut Data Query Server SHALL: Support json resource formats for all Argonaut Data Query interactions.' do
     assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
     assert @conformance.format.include?('json') || @conformance.format.include?('application/json+fhir'), 'Conformance does not state support for json.'
   end
 
-  test 'Conformance lists valid OAuth 2.0 endpoints' do
+  test 'Conformance lists OAuth 2.0 authorize and token endpoints',
+         'http://www.hl7.org/fhir/smart-app-launch/capability-statement/',
+         'If a server requires SMART on FHIR authorization for access, its metadata must support automated dicovery of OAuth2 endpoints' do
     assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
     oauth_metadata = @client.get_oauth2_metadata_from_conformance
     assert !oauth_metadata.nil?, 'No OAuth Metadata in conformance statement'
@@ -35,13 +39,19 @@ class ConformanceSequence < SequenceBase
       registration_url = registration_url.value if registration_url
       assert !registration_url.blank?,  'No dynamic registration endpoint in conformance.'
       assert (registration_url =~ /\A#{URI::regexp(['http', 'https'])}\z/) == 0, "Invalid registration url: '#{registration_url}'"
+
+      manage_url = security_info.extension.find{|x| x.url == 'manage'}
+      manage_url = manage_url.value if manage_url
+      assert !manage_url.blank?,  'No user-facing authorization management workflow entry point for this FHIR server.'
     }
 
     @instance.update(oauth_authorize_endpoint: authorize_url, oauth_token_endpoint: token_url, oauth_register_endpoint: registration_url)
   end
 
-  test 'Conformance statement lists core capabilities' do
-    assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
+  test 'Conformance statement lists core capabilities',
+    'http://www.hl7.org/fhir/smart-app-launch/conformance/',
+    'A SMART on FHIR server can convey its capabilities to app developers by listing a set of the capabilities',
+    :optional do
 
     required_capabilities = ['launch-ehr',
       'launch-standalone',
@@ -56,13 +66,21 @@ class ConformanceSequence < SequenceBase
       'permission-user'
     ]
 
-    warning {
-      capabilities = @conformance.rest.first.security.extension.find{|x| x.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities' }
-      assert !capabilities.nil?, 'No SMART capabilities listed in conformance.'
-      available_capabilities = capabilities.map{ |v| v['valueCode']}
-      missing_capabilities = (required_capabilities - available_capabilities)
-      assert missing_capabilities.empty?, "Conformance statement does not list required SMART capabilties: #{missing_capabilities.join(', ')}"
-    }
+    assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
+    capabilities = @conformance.rest.first.security.extension.find{|x| x.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities' }
+    assert !capabilities.nil?, 'No SMART capabilities listed in conformance.'
+    available_capabilities = capabilities.map{ |v| v['valueCode']}
+    missing_capabilities = (required_capabilities - available_capabilities)
+    assert missing_capabilities.empty?, "Conformance statement does not list required SMART capabilties: #{missing_capabilities.join(', ')}"
+  end
+
+  test 'Conformance lists supported Argonaut profiles, as well as supported operatations and search parameters', 
+    'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+    'The Argonaut Data Query Server shall declare a Conformance identifying the list of profiles, operations, search parameter supported.' do
+
+     assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
+
+     #todo
   end
 
 end

--- a/lib/sequences/02_dynamic_registration_sequence.rb
+++ b/lib/sequences/02_dynamic_registration_sequence.rb
@@ -10,7 +10,18 @@ class DynamicRegistrationSequence < SequenceBase
     !@instance.oauth_authorize_endpoint.nil? && !@instance.oauth_token_endpoint.nil?
   end
 
-  test 'OAuth 2.0 Dynamic Client Registration Protocol' do
+  # TODO: TLS SECURITY
+  test 'Client registration endpoint secured by a transport-layer security.', 
+    'https://tools.ietf.org/html/rfc7591',
+    'The client registration endpoint MUST be protected by a transport-layer security' do
+
+    assert @instance.oauth_register_endpoint.start_with?('https'), 'Client registration endpoint not secured.' #TODO: INSUFFICENT
+  end
+
+
+  test 'Client registration endpoint accepts POST messages', 
+    'https://tools.ietf.org/html/rfc7591',
+    'The client registration endpoint MUST accept HTTP POST messages. with request parameters encoded in the entity body using the "application/json" format' do
     # params['redirect_uris'] = [params['redirect_uris']]
     # params['grant_types'] = params['grant_types'].split(',')
     headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/json' }
@@ -24,14 +35,32 @@ class DynamicRegistrationSequence < SequenceBase
       'scope' => @instance.scopes,
     }
 
-    registration_response = LoggedRestClient.post(@instance.oauth_register_endpoint, params.to_json, headers)
-    registration_response = JSON.parse(registration_response.body)
-    if registration_response['error'] || registration_response['error_description']
-      # check error
+    @registration_response = LoggedRestClient.post(@instance.oauth_register_endpoint, params.to_json, headers)
+    @registration_response_body = JSON.parse(@registration_response.body)
 
-    end
-
-    # check to make sure that values are the same as what what submitted
-    @instance.update(client_id: registration_response['client_id'], dynamically_registered: true, scopes: registration_response['scope'])
   end
+
+  test 'Registration endpoint does not respond with an error.', 
+    'https://tools.ietf.org/html/rfc7591',
+    'When an OAuth 2.0 error condition occurs, such as the client presenting an invalid initial access token, the authorization server returns an error response appropriate to the OAuth 2.0 token type.' do
+
+      assert !@registration_response_body.has_key?('error') && !@registration_response_body.has_key?('error_description'), 
+                "Error returned.  Error: #{@registration_response_body['error']}, Description: #{@registration_response_body['error_description']}"
+
+  end
+
+  test 'Registration endpoint responds with HTTP 201 and body contains JSON with required fields.', 
+    'https://tools.ietf.org/html/rfc7591',
+    'The server responds with an HTTP 201 Created status code and a body of type "application/json" with content as described in Section 3.2.1.' do
+
+
+    assert @registration_response.code == 201, "Expected HTTP 201 response from registration endpoint but received #{@registration_response.code}"
+    assert @registration_response_body.has_key?('client_id') && @registration_response_body.has_key?('scope'), 'Registration response did not include client_id and scope fields in JSON body' 
+
+
+    # TODO: check all values, and not just client and scope
+    
+    @instance.update(client_id: @registration_response_body['client_id'], dynamically_registered: true, scopes: @registration_response_body['scope'])
+  end
+
 end

--- a/lib/sequences/03_patient_standalone_launch_sequence.rb
+++ b/lib/sequences/03_patient_standalone_launch_sequence.rb
@@ -8,7 +8,9 @@ class PatientStandaloneLaunchSequence < SequenceBase
     !@instance.client_id.nil?
   end
 
-  test 'Client successfully redirected back to redirect url' do 
+  test 'Client browser redirected from OAuth server to app redirect uri',
+    'http://www.hl7.org/fhir/smart-app-launch/',
+    'Client browser redirected from OAuth server to redirect uri of client app as described in SMART authorization sequence.'  do 
 
     @instance.state = SecureRandom.uuid
 
@@ -36,12 +38,19 @@ class PatientStandaloneLaunchSequence < SequenceBase
     redirect oauth2_auth_query[0..-2], 'redirect'
   end
 
-  test 'OAuth Server hit redirect url proper values' do
+  test 'Client app received code parameter and correct state paramater from OAuth server at redirect uri.',
+    'http://www.hl7.org/fhir/smart-app-launch/',
+    'Code and state are required querystring parameters.  State must be the exact value received from the client.'  do 
+
     assert @params['error'].nil?, "Error returned from authorization server:  code #{@params['error']}, description: #{@params['error_description']}"
+    assert @params['state'] == @instance.state, "OAuth server state querystring parameter (#{@params['state']}) did not match state from app #{@instance.state}"
     assert !@params['code'].nil?, "Expected code to be submitted in request"
   end
 
-  test 'Token exchange endpoint responds.' do
+  test 'OAuth Token exchange endpoint responds to POST using content type application/x-www-form-urlencoded.',
+    'http://www.hl7.org/fhir/smart-app-launch/',
+    'After obtaining an authorization code, the app trades the code for an access token via HTTP POST to the EHR authorization server’s token endpoint URL, using content-type application/x-www-form-urlencoded, as described in section 4.1.3 of RFC6749' do
+
     oauth2_params = {
       'grant_type' => 'authorization_code',
       'code' => @params['code'],
@@ -53,18 +62,34 @@ class PatientStandaloneLaunchSequence < SequenceBase
 
   end
 
-  test 'Data returned from token exchange contains token contains expected information.' do
+  test 'Data returned from token exchange contains required information encoded in JSON.',
+    'http://www.hl7.org/fhir/smart-app-launch/',
+    'The EHR authorization server SHALL return a JSON structure that includes an access token or a message indicating that the authorization request has been denied. '\
+    'access_token, token_type, and scope are required. access_token must be Bearer.' do
+
     @token_response = JSON.parse(@token_response.body)
 
-    #TODO add assertions here
+    ['access_token', 'token_type', 'scope'].each do |key|
+      assert @token_response.has_key?(key), "Token response did not contain #{key} as required"
+    end
 
-    token = @token_response['access_token']
-    patient_id = @token_response['patient']
+    expected_scopes = @instance.scopes.split(' ')
+    actual_scopes = @token_response['scope'].split(' ')
+    
+    warning {
+      missing_scopes = (expected_scopes - actual_scopes)
+      assert missing_scopes.empty?, "Token exchange response did not include expected scopes: #{missing_scopes}"
+
+      assert @token_response.has_key?('patient'), 'No patient id provided in token exchange.'
+    }
+
+    assert @token_response['token_type'] == 'Bearer', 'Token type must be Bearer.'
+    
     scopes = @token_response['scope'] || @instance.scopes
     token_retrieved_at = DateTime.now
-    
+
     @instance.save!
-    @instance.update(token: token, patient_id: patient_id, scopes: scopes, token_retrieved_at: token_retrieved_at)
+    @instance.update(token: @token_response['access_token'], patient_id: @token_response['patient'], scopes: scopes, token_retrieved_at: token_retrieved_at)
 
   end
 

--- a/lib/sequences/05_token_introspection_sequence.rb
+++ b/lib/sequences/05_token_introspection_sequence.rb
@@ -42,18 +42,18 @@ class TokenIntrospectionSequence < SequenceBase
 
   test 'Scopes match',
           'https://tools.ietf.org/html/rfc7662',
-          'The scopes we received alongside the token match those from the introspection response' do
+          'The scopes we received alongside the token match those from the introspection response',
+          :optional do
 
     expected_scopes = @instance.scopes.split(' ')
     actual_scopes = @introspection_response['scope'].split(' ')
     
     FHIR.logger.debug "Introspection: Expected scopes #{expected_scopes}, Actual scopes #{actual_scopes}"
     
-    warning {
-      missing_scopes = (expected_scopes - actual_scopes)
-      assert missing_scopes.empty?, "Introspection response did not include expected scopes: #{missing_scopes}"
-    }
+    missing_scopes = (expected_scopes - actual_scopes)
+    assert missing_scopes.empty?, "Introspection response did not include expected scopes: #{missing_scopes}"
     extra_scopes = (actual_scopes - expected_scopes)
+
     assert extra_scopes.empty?, "Introspection response included additional scopes: #{extra_scopes}"
     
   end

--- a/lib/sequences/06_argonaut_profiles_sequence.rb
+++ b/lib/sequences/06_argonaut_profiles_sequence.rb
@@ -12,8 +12,9 @@ class ArgonautProfilesSequence < SequenceBase
   # Patient Profile
   # --------------------------------------------------
 
-  test 'Has Patient resource',
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html' do
+  test 'Valid DSTU2 patient resource provided and is accessable via read',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A server is capable of returning a patient using GET [base]/Patient/[id].' do
 
     patient_read_response = @client.read(FHIR::DSTU2::Patient, @instance.patient_id)
     assert_response_ok patient_read_response
@@ -23,14 +24,16 @@ class ArgonautProfilesSequence < SequenceBase
   end
 
   test 'Patient validates against Argonaut Profile',
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html' do
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'A server returns valid FHIR Patient resources according to the Data Access Framework (DAF) Patient Profile (http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-patient.html)' do
+
     profile = ValidationUtil.guess_profile(@patient)
     errors = profile.validate_resource(@patient)
     assert errors.empty?, "Patient did not validate against profile: #{errors.join(", ")}"
   end
 
   test 'Patient has address',
-          nil,
+          '',
           'Additional Patient resource requirement' do
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
@@ -40,7 +43,7 @@ class ArgonautProfilesSequence < SequenceBase
   end
 
   test 'Patient has telecom',
-          nil,
+          '',
           'Additional Patient resource requirement' do
 
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
@@ -49,7 +52,7 @@ class ArgonautProfilesSequence < SequenceBase
     assert !telecom.nil?, 'Patient telecom not returned'
   end
 
-  test 'Patient supports $everything operation', '' do
+  test 'Patient supports $everything operation', '', 'DISCUSSION REQUIRED', :optional do
     everything_response = @client.fetch_patient_record(@instance.patient_id)
     skip_unless [200, 201].include?(everything_response.code)
     @everything = everything_response.resource
@@ -58,7 +61,7 @@ class ArgonautProfilesSequence < SequenceBase
   end
 
   test 'Resources in the Patient $everything results conform to Argonaut profiles',
-          'http://www.fhir.org/guides/argonaut/r2/profiles.html' do
+          'http://www.fhir.org/guides/argonaut/r2/profiles.html', 'DISCUSSION REQUIRED', :optional do
 
     skip_unless !@everything.nil?, 'Expected valid DSTU2 Bundle to be present as a result of $everything request'
     assert @everything.is_a?(FHIR::DSTU2::Bundle), 'Expected resource to be valid DSTU2 Bundle'
@@ -122,91 +125,107 @@ class ArgonautProfilesSequence < SequenceBase
     assert(all_errors.empty?, all_errors.join("<br/>\n"))
   end
 
-  test "AllergyIntolerance resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-allergyintolerance.html' do
+  test 'AllergyIntolerance resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-allergyintolerance.html',
+          'AllergyIntolerance resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('AllergyIntolerance')
   end
 
-  test "CarePlan resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careplan.html' do
+  test 'CarePlan resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careplan.html',
+         'Declare a Conformance identifying the list of profiles, operations, search parameter supported.' do
     test_resources_against_profile('CarePlan', ValidationUtil::CARE_PLAN_URL)
     skip_unless @profiles_encountered.include?(ValidationUtil::CARE_PLAN_URL), 'No CarePlans found.'
     assert !@profiles_failed.include?(ValidationUtil::CARE_PLAN_URL), "CarePlans failed validation.<br/>#{@profiles_failed[ValidationUtil::CARE_PLAN_URL]}"
   end
 
-  test "CareTeam resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careteam.html' do
+  test 'CareTeam resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-careteam.html',
+         'Declare a Conformance identifying the list of profiles, operations, search parameter supported.' do
     test_resources_against_profile('CarePlan', ValidationUtil::CARE_TEAM_URL)
     skip_unless @profiles_encountered.include?(ValidationUtil::CARE_TEAM_URL), 'No CareTeams found.'
     assert !@profiles_failed.include?(ValidationUtil::CARE_TEAM_URL), "CareTeams failed validation.<br/>#{@profiles_failed[ValidationUtil::CARE_TEAM_URL]}"
   end
 
-  test "Condition resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-condition.html' do
+  test 'Condition resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-condition.html',
+         'Condition resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('Condition')
   end
 
-  test "Device resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-device.html' do
+  test 'Device resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-device.html',
+          'Device resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('Device')
   end
 
-  test "DiagnosticReport resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html' do
+  test 'DiagnosticReport resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-diagnosticreport.html',
+         'DiagnosticReport resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('DiagnosticReport')
   end
 
-  test "DocumentReference resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-documentreference.html' do
+  test 'DocumentReference resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-documentreference.html',
+          'DocumentReference resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('DocumentReference')
   end
 
-  test "Goal resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-goal.html' do
+  test 'Goal resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-goal.html',
+          'DocumentReference resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('Goal')
   end
 
-  test "Immunization resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-immunization.html' do
+  test 'Immunization resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-immunization.html',
+          'Immunization resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('Immunization')
   end
 
-  test "Medication resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medication.html' do
+  test 'Medication resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medication.html',
+          'Medication resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('Medication')
   end
 
-  test "MedicationOrder resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html' do
+  test 'MedicationOrder resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationorder.html',
+          'MedicationOrder resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('MedicationOrder')
   end
 
-  test "MedicationStatement resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationstatement.html' do
+  test 'MedicationStatement resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-medicationstatement.html',
+          'MedicationStatement resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('MedicationStatement')
   end
 
-  test "Observation Result resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html' do
+  test 'Observation Result resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-observationresults.html',
+          'Observation Result resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('Observation', ValidationUtil::OBSERVATION_RESULTS_URL)
     skip_unless @profiles_encountered.include?(ValidationUtil::OBSERVATION_RESULTS_URL), 'No Observation Results found.'
     assert !@profiles_failed.include?(ValidationUtil::OBSERVATION_RESULTS_URL), "Observation Results failed validation.<br/>#{@profiles_failed[ValidationUtil::OBSERVATION_RESULTS_URL]}"
   end
 
-  test "Procedure resources associated with Procedure conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-procedure.html' do
+  test 'Procedure resources associated with Procedure conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-procedure.html',
+          'Procedure resources associated with Procedure conform to Argonaut profiles' do
     test_resources_against_profile('Procedure')
   end
 
-  test "Smoking Status resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-smokingstatus.html' do
+  test 'Smoking Status resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-smokingstatus.html',
+          'Procedure resources associated with Procedure conform to Argonaut profiles' do
     test_resources_against_profile('Observation', ValidationUtil::SMOKING_STATUS_URL)
     skip_unless @profiles_encountered.include?(ValidationUtil::SMOKING_STATUS_URL), 'No Smoking Status Observations found.'
     assert !@profiles_failed.include?(ValidationUtil::SMOKING_STATUS_URL), "Smoking Status Observations failed validation.<br/>#{@profiles_failed[ValidationUtil::SMOKING_STATUS_URL]}"
   end
 
-  test "Vital Signs resources associated with Patient conform to Argonaut profiles",
-          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-vitalsigns.html' do
+  test 'Vital Signs resources associated with Patient conform to Argonaut profiles',
+          'http://www.fhir.org/guides/argonaut/r2/StructureDefinition-argo-vitalsigns.html',
+          'Vital Signs resources associated with Patient conform to Argonaut profiles' do
     test_resources_against_profile('Observation', ValidationUtil::VITAL_SIGNS_URL)
     skip_unless @profiles_encountered.include?(ValidationUtil::VITAL_SIGNS_URL), 'No Vital Sign Observations found.'
     assert !@profiles_failed.include?(ValidationUtil::VITAL_SIGNS_URL), "Vital Sign Observations failed validation.<br/>#{@profiles_failed[ValidationUtil::VITAL_SIGNS_URL]}"

--- a/lib/sequences/07_argonaut_search_sequence.rb
+++ b/lib/sequences/07_argonaut_search_sequence.rb
@@ -1,6 +1,6 @@
-class ArgonautSearchSequence < SequenceBase
+class ArgonautDataQuerySequence < SequenceBase
 
-  title 'Argonaut Search'
+  title 'Argonaut Data Query'
 
   description 'The FHIR server properly follows the Argonaut Data Query Implementation Guide Server.'
 
@@ -46,15 +46,23 @@ class ArgonautSearchSequence < SequenceBase
   # Patient Search
   # --------------------------------------------------
 
-  test 'Has Patient resource',
+  test 'Patient read resource supported',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'A server is capable of returning a patient using GET [base]/Patient/[id]' do
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
 
     patient_read_response = @client.read(FHIR::DSTU2::Patient, @instance.patient_id)
     assert_response_ok patient_read_response
     @patient = patient_read_response.resource
     assert !@patient.nil?, 'Expected valid DSTU2 Patient resource to be present'
     assert @patient.is_a?(FHIR::DSTU2::Patient), 'Expected resource to be valid DSTU2 Patient'
+
+  end
+
+  test 'Patient history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
 
   end
 
@@ -154,6 +162,23 @@ class ArgonautSearchSequence < SequenceBase
 
   end
 
+  test 'AllergyIntolerance read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'AllergyIntolerance history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
+
+  end
+
+
   # --------------------------------------------------
   # CarePlan Search
   # --------------------------------------------------
@@ -218,6 +243,23 @@ class ArgonautSearchSequence < SequenceBase
 
   end
 
+  test 'CarePlan read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'CarePlan history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
+
+  end
+
+
   # --------------------------------------------------
   # Condition Search
   # --------------------------------------------------
@@ -275,6 +317,23 @@ class ArgonautSearchSequence < SequenceBase
 
   end
 
+  test 'Condition read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'Condition history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
+
+  end
+
+
   # --------------------------------------------------
   # Device Search
   # --------------------------------------------------
@@ -298,6 +357,23 @@ class ArgonautSearchSequence < SequenceBase
     validate_reply(FHIR::DSTU2::Device, reply)
 
   end
+
+  test 'Device read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'Device history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
+
+  end
+
 
   # --------------------------------------------------
   # Goal Search
@@ -336,6 +412,23 @@ class ArgonautSearchSequence < SequenceBase
 
   end
 
+  test 'Goal read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'Goal history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
+
+  end
+
+
   # --------------------------------------------------
   # Immunization Search
   # --------------------------------------------------
@@ -359,6 +452,23 @@ class ArgonautSearchSequence < SequenceBase
     validate_reply(FHIR::DSTU2::Immunization, reply)
 
   end
+
+  test 'Immunization read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'Immunization history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
+
+  end
+
 
   # --------------------------------------------------
   # DiagnosticReport Search
@@ -425,6 +535,22 @@ class ArgonautSearchSequence < SequenceBase
 
   end
 
+  test 'DiagnosticReport read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'DiagnosticReport history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
+
+  end
+
   # --------------------------------------------------
   # MedicationStatement Search
   # --------------------------------------------------
@@ -449,6 +575,23 @@ class ArgonautSearchSequence < SequenceBase
 
   end
 
+  test 'MedicationStatement read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'MedicationStatement history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
+
+  end
+
+
   # --------------------------------------------------
   # MedicationOrder Search
   # --------------------------------------------------
@@ -472,6 +615,23 @@ class ArgonautSearchSequence < SequenceBase
     validate_reply(FHIR::DSTU2::MedicationOrder, reply)
 
   end
+
+  test 'MedicationOrder read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'MedicationOrder history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
+
+  end
+
 
   # --------------------------------------------------
   # Observation Search
@@ -546,6 +706,22 @@ class ArgonautSearchSequence < SequenceBase
     reply = get_resource_by_params(FHIR::DSTU2::Observation, {patient: @instance.patient_id, code: "72166-2"})
     @client.set_bearer_token(@instance.token)
     assert_response_unauthorized reply
+
+  end
+
+  test 'Observation read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'Observation history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
 
   end
 
@@ -653,6 +829,22 @@ class ArgonautSearchSequence < SequenceBase
     assert !date.nil?, "Procedure performedDateTime not returned"
     reply = get_resource_by_params(FHIR::DSTU2::Procedure, {patient: @instance.patient_id, date: date})
     validate_reply(FHIR::DSTU2::Procedure, reply)
+
+  end
+
+  test 'Procedure read resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHALL make available the read interactions for the Argonaut Profiles the server chooses to support.' do
+
+    todo
+
+  end
+
+  test 'Procedure history and vread resource supported',
+          'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
+          'All servers SHOULD make available the vread and history-instance interactions for the Argonaut Profiles the server chooses to support. ' do
+
+    todo
 
   end
 

--- a/lib/sequences/07_argonaut_search_sequence.rb
+++ b/lib/sequences/07_argonaut_search_sequence.rb
@@ -206,7 +206,7 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'CarePlan search by patient + category + status + date',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'A server SHOULD be capable returning a patient’s active Assessment and Plan of Treatment information over a specified time period using GET /CarePlan?patient=[id]&category=assess-plan&status=active&date=[date]' do
+          'A server SHOULD be capable returning a patients active Assessment and Plan of Treatment information over a specified time period using GET /CarePlan?patient=[id]&category=assess-plan&status=active&date=[date]' do
 
     warning {
       assert !@careplan.nil?, 'Expected valid DSTU2 CarePlan resource to be present'
@@ -235,7 +235,7 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'Condition search by patient',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'A server is capable of returning a patient’s conditions list using GET/Condition?patient=[id]' do
+          'A server is capable of returning a patients conditions list using GET/Condition?patient=[id]' do
 
     reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id})
     validate_reply(FHIR::DSTU2::Condition, reply)
@@ -244,7 +244,7 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'Condition search by patient + clinicalstatus',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'A server SHOULD be capable returning all of a patient’s active problems and health concerns using ‘GET /Condition?patient=[id]&clinicalstatus=active,recurrance,remission' do
+          'A server SHOULD be capable returning all of a patients active problems and health concerns using ‘GET /Condition?patient=[id]&clinicalstatus=active,recurrance,remission' do
 
     warning {
       reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id, clinicalstatus: "active,recurrance,remission"})
@@ -255,7 +255,7 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'Condition search by patient + problem category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'A server SHOULD be capable returning all of a patient’s problems or all of patient’s health concerns using ‘GET /Condition?patient=[id]&category=[problem|health-concern]' do
+          'A server SHOULD be capable returning all of a patients problems or all of patients health concerns using ‘GET /Condition?patient=[id]&category=[problem|health-concern]' do
 
     warning {
       reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id, category: "problem"})
@@ -266,7 +266,7 @@ class ArgonautSearchSequence < SequenceBase
 
   test 'Condition search by patient + health-concern category',
           'http://www.fhir.org/guides/argonaut/r2/Conformance-server.html',
-          'A server SHOULD be capable returning all of a patient’s problems or all of patient’s health concerns using ‘GET /Condition?patient=[id]&category=[problem|health-concern]' do
+          'A server SHOULD be capable returning all of a patients problems or all of patients health concerns using ‘GET /Condition?patient=[id]&category=[problem|health-concern]' do
 
     warning {
       reply = get_resource_by_params(FHIR::DSTU2::Condition, {patient: @instance.patient_id, category: "health-concern"})

--- a/lib/sequences/08_additional_resources_sequence.rb
+++ b/lib/sequences/08_additional_resources_sequence.rb
@@ -1,0 +1,82 @@
+class AdditionalResourcesSequence < SequenceBase
+
+  title 'Additional Resources'
+
+  description 'The FHIR server properly follows the Argonaut Data Query Implementation Guide Server.'
+
+  preconditions 'Client must be authorized.' do
+    !@instance.token.nil?
+  end
+
+  test 'Composition not accessible without authorization',
+          '',
+          '' do
+    todo
+  end
+
+  test 'Read Composition Resource',
+          'https://www.hl7.org/fhir/DSTU2/composition.html',
+          '' do
+    todo
+
+  end
+
+  test 'Search Composition resource supported',
+          'https://www.hl7.org/fhir/DSTU2/composition.html',
+          '',
+          :optional do
+    todo
+
+  end
+
+  test 'Composition resource valid',
+          'https://www.hl7.org/fhir/DSTU2/composition.html',
+          '' do
+    todo
+
+  end
+          
+  test 'Composition resource contains Section.text',
+          '',
+          '' do
+    todo
+
+  end
+
+  test 'Provenance not accessible without authorization',
+          '',
+          '' do
+    todo
+  end
+
+  test 'Read Provenance resource supported',
+          'https://www.hl7.org/fhir/DSTU2/provenance.html',
+          '' do
+    todo
+
+  end
+
+  test 'Search Provenance resource supported',
+          'https://www.hl7.org/fhir/DSTU2/composition.html',
+          '',
+          :optional do
+    todo
+
+  end
+
+  test 'Provenance Resource Valid',
+          'https://www.hl7.org/fhir/DSTU2/provenance.html',
+          '' do
+    todo
+
+  end
+
+  test 'Supports read DSTU2 Provenance Resource',
+          'https://www.hl7.org/fhir/DSTU2/provenance.html',
+          '' do
+    todo
+
+  end
+
+
+end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -13,17 +13,17 @@ end
 desc 'Generate List of All Tests'
 task :tests_to_csv do
 
-  flat_tests = SequenceBase.subclasses.map do |klass|
+  flat_tests = SequenceBase.ordered_sequences.map do |klass|
     klass.tests.map do |test|
       test[:sequence] = klass.to_s
       test
     end
-  end.flatten.sort_by { |t| t[:test_index] }
+  end.flatten
 
   csv_out = CSV.generate do |csv|
-    csv << ['Sequence', 'Name', 'Description', 'Url']
+    csv << ['Sequence', 'Name', 'Required', 'Description', 'Url']
     flat_tests.each do |test|
-      csv <<  [ test[:sequence], test[:name], test[:description], test[:url] ]
+      csv <<  [ test[:sequence], test[:name], test[:required], test[:description], test[:url] ]
     end
   end
 

--- a/models/TestResult.rb
+++ b/models/TestResult.rb
@@ -4,6 +4,7 @@ class TestResult
   property :name, String
   property :result, String
   property :message, String, length: 500
+  property :required, Boolean, default: true
 
   property :url, String, length: 500
   property :description, Text

--- a/test/sequence/conformance_test.rb
+++ b/test/sequence/conformance_test.rb
@@ -37,7 +37,8 @@ class ConformanceSequenceTest < MiniTest::Unit::TestCase
 
     sequence_result = @sequence.start
     assert sequence_result.result == 'fail'
-    assert sequence_result.test_results.all?{|r| r.result == 'fail'}
+    assert sequence_result.test_results.select{|r| !r.required}.length == 1
+    assert sequence_result.test_results.all?{|r| r.result == 'fail' || !r.required}
   end
 
 end

--- a/test/sequence/dynamic_registration_test.rb
+++ b/test/sequence/dynamic_registration_test.rb
@@ -14,7 +14,7 @@ class DynamicRegistrationSequenceTest < MiniTest::Unit::TestCase
                                    client_name: 'Crucible Smart App',
                                    base_url: 'http://localhost:4567',
                                    client_endpoint_key: SecureRandomBase62.generate(32),
-                                   oauth_register_endpoint: 'http://oauth_reg.example.com/register',
+                                   oauth_register_endpoint: 'https://oauth_reg.example.com/register',
                                    scopes: 'launch openid patient/*.* profile'
                                    )
     @instance.save! # this is for convenience.  we could rewrite to ensure nothing gets saved within tests.
@@ -31,11 +31,14 @@ class DynamicRegistrationSequenceTest < MiniTest::Unit::TestCase
 
     stub_request(:post, @instance.oauth_register_endpoint).
       with(headers: headers).
-      to_return(status: 200, body: @dynamic_registration.to_json, headers: RESPONSE_HEADERS)
+      to_return(status: 201, body: @dynamic_registration.to_json, headers: RESPONSE_HEADERS)
 
     sequence_result = @sequence.start
+
+    failures = sequence_result.test_results.select{|r| r.result != 'pass'}
+
+    assert failures.length == 0, "All tests should pass.  First error: #{!failures.empty? && failures.first.message}"
     assert sequence_result.result == 'pass', 'Sequence should pass'
-    assert sequence_result.test_results.all?{|r| r.result == 'pass'}, 'All tests should pass'
     assert sequence_result.test_results.all?{|r| r.test_warnings.empty? }, 'There should not be any warnings.'
   end
 

--- a/test/sequence/ehr_launch_test.rb
+++ b/test/sequence/ehr_launch_test.rb
@@ -45,13 +45,15 @@ class EHRLaunchSequenceTest < MiniTest::Unit::TestCase
     assert sequence_result.redirect_to_url.start_with? @instance.oauth_authorize_endpoint, 'The sequence should be redirecting to the authorize url'
     assert sequence_result.wait_at_endpoint == 'redirect', 'The sequence should be waiting at a redirect url'
 
-    redirect_params = {"code"=>"5N01E0", "state"=>"7c39b192-d2e4-47ba-a23e-d2735b560c38"}
+    redirect_params = {'code'=>'5N01E0', 'state'=>@instance.state}
 
     sequence_result = @sequence.resume(nil, nil, redirect_params)
-    
+
+    failures = sequence_result.test_results.select{|r| r.result != 'pass'}
+    assert failures.length == 0, "All tests should pass.  First error: #{!failures.empty? && failures.first.message}"
     assert sequence_result.result == 'pass', 'Sequence should pass'
-    assert sequence_result.test_results.all?{|r| r.result == 'pass'}, 'All tests should pass'
     assert sequence_result.test_results.all?{|r| r.test_warnings.empty? }, 'There should not be any warnings.'
+
   end
 
 end

--- a/test/unit/sequence_validation_test.rb
+++ b/test/unit/sequence_validation_test.rb
@@ -1,0 +1,45 @@
+require File.expand_path '../../test_helper.rb', __FILE__
+
+# These test structure and metadata within sequences but do not execute them.
+# Sequence execution tests are in the /test/sequence directory.
+
+class SequenceValidationTest < MiniTest::Unit::TestCase
+
+  def valid_url?(url)
+    !(url =~ /\A#{URI::regexp(['http', 'https'])}\z/).nil?
+  end
+
+  def setup
+    @sequences = SequenceBase.subclasses
+  end
+
+  def test_metadata
+
+    # additonal requiremetns
+    excluded_tests = ['Patient has address', 'Patient has telecom', 'Token expiration']
+
+    # questionable requirements
+    excluded_tests << 'Patient supports $everything operation'
+
+    # not yet finished
+    AdditionalResourcesSequence.tests.each { |test| excluded_tests << test[:name]}
+
+    test_list = @sequences.map do |sequence|
+      test_list = sequence.tests.map {|test| test[:sequence] = sequence.name; test}
+    end.flatten
+
+    test_list.select!{ |test| !excluded_tests.include?(test[:name])}
+
+    incomplete_metadata_tests = test_list.select{ |test| test[:name].nil? || test[:description].nil? || !valid_url?(test[:url])}
+
+    assert incomplete_metadata_tests.empty?, "Found #{incomplete_metadata_tests.length} tests with incomplete metadata."\
+      "First: #{!incomplete_metadata_tests.empty? && incomplete_metadata_tests.first[:sequence]}: #{!incomplete_metadata_tests.empty? && incomplete_metadata_tests.first[:name]}"
+  end
+
+  def test_ordered_sequences
+
+    assert SequenceBase.ordered_sequences.uniq.length == SequenceBase.ordered_sequences.length, 'There are duplicate sequences in SequenceBase.ordered_sequences.'
+    assert (SequenceBase.subclasses-SequenceBase.ordered_sequences).blank?  && (SequenceBase.ordered_sequences-SequenceBase.subclasses).blank?, 'SequenceBase.ordered_sequences does not contain correct subclasses.  Please update method in SequenceBase.'
+  end
+
+end

--- a/views/test_list.erb
+++ b/views/test_list.erb
@@ -52,6 +52,7 @@
 
         <% if result.result == 'todo' %> TODO: <% end %>
         <%= result.name %>
+        <% unless result.required %> (optional) <% end %>
         <% if result.result == 'fail' || result.result == 'error' %>
           <div class="result-details-message">
             Failure Message: <%= result.message %>

--- a/views/test_result_details.erb
+++ b/views/test_result_details.erb
@@ -29,6 +29,7 @@
         </div>
       <% end %>
       <%= @test_result.name %>
+      <% unless @test_result.required %> (optional) <% end %>
     </div>
 
     <% unless @test_result.message.nil? %>


### PR DESCRIPTION
Fill out test metadata for all tests that did not have complete metadata.   Adds optional test functionality, so it could be exported to csv and automatically set results to warnings.  Cleaned up a few other areas.