### PR TITLE
Update travis ruby versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: ruby
 cache: bundler
 sudo: required
 rvm:
-  - 2.2.9
+  - 2.3
+  - 2.4
+  - 2.5
 notifications:
   email:
     recipients:


### PR DESCRIPTION
2.2 is EOL at the end of March, and 2.5 was released in December.