### PR TITLE
Update how optionoal tests return and UI updates

### DIFF
--- a/lib/sequences/01_conformance_sequence.rb
+++ b/lib/sequences/01_conformance_sequence.rb
@@ -67,9 +67,9 @@ class ConformanceSequence < SequenceBase
     ]
 
     assert @conformance.class == FHIR::DSTU2::Conformance, 'Expected valid DSTU2 Conformance resource'
-    capabilities = @conformance.rest.first.security.extension.find{|x| x.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities' }
+    capabilities = @conformance.rest.first.security.extension.select{|x| x.url == 'http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities' }
     assert !capabilities.nil?, 'No SMART capabilities listed in conformance.'
-    available_capabilities = capabilities.map{ |v| v['valueCode']}
+    available_capabilities = capabilities.map{ |v| v.valueCode}
     missing_capabilities = (required_capabilities - available_capabilities)
     assert missing_capabilities.empty?, "Conformance statement does not list required SMART capabilties: #{missing_capabilities.join(', ')}"
   end

--- a/models/SequenceResult.rb
+++ b/models/SequenceResult.rb
@@ -10,7 +10,6 @@ class SequenceResult
   property :passed_count, Integer, default: 0
   property :failed_count, Integer, default: 0
   property :error_count, Integer, default: 0
-  property :warning_count, Integer, default: 0
   property :todo_count, Integer, default: 0
   property :skip_count, Integer, default: 0
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -325,6 +325,11 @@ li.result-details-clickable:hover {
   padding-top: 3px;
 }
 
+.result-details-icon-fail-optional {
+  color: #999;
+  padding-top: 3px;
+}
+
 .result-details-icon-cancel {
   color: #f00;
   padding-top: 3px;
@@ -355,10 +360,12 @@ li.result-details-clickable:hover {
 
 .result-details-icon-warning {
   color: #FF9500;
+  float: right;
 }
 
 .result-details-icon-requests {
   color: #336699;
+  float: right;
 }
 
 .result-details-message {

--- a/test/fixtures/conformance_statement.json
+++ b/test/fixtures/conformance_statement.json
@@ -37,7 +37,50 @@
                 "valueUri": "https://sb-auth.smarthealthit.org/register"
               }
             ]
+          } , {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "launch-ehr"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "launch-standalone"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "client-public"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "client-confidential-symmetric"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "sso-openid-connect"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "context-banner"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "context-style"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "context-ehr-patient"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "context-ehr-encounter"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "context-standalone-patient"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "context-standalone-encounter"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "permission-offline"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "permission-patient"
+          }, {
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/capabilities",
+            "valueCode": "permission-user"
           }
+
         ],
         "service": [
           {

--- a/views/sequence.erb
+++ b/views/sequence.erb
@@ -45,14 +45,9 @@
           Test manually verified
         <% else %>
           <%= sequence_results[sequence_class.sequence_name].passed_count %> Passed -
-          <%= sequence_results[sequence_class.sequence_name].failed_count %> Failed -
-          <%= sequence_results[sequence_class.sequence_name].error_count %> Error(s) -
-          <%= sequence_results[sequence_class.sequence_name].warning_count %> Warning(s)
+          <%= sequence_results[sequence_class.sequence_name].failed_count %> Failed
           <% if sequence_results[sequence_class.sequence_name].skip_count > 0 %> -
-            <%= sequence_results[sequence_class.sequence_name].skip_count %> Skips(s)
-          <% end %>
-          <% if sequence_results[sequence_class.sequence_name].todo_count > 0 %> -
-            <%= sequence_results[sequence_class.sequence_name].todo_count %> Todo(s)
+            <%= sequence_results[sequence_class.sequence_name].skip_count %> Skipped
           <% end %>
 
         <% end %>

--- a/views/test_list.erb
+++ b/views/test_list.erb
@@ -4,58 +4,71 @@
       <li class="result-details-clickable" data-testing-instance-id="<%=sequence_result.testing_instance.id%>" data-test-result-id="<%=result.id%>">
         <% case result.result
           when 'pass' %>
-            <div class="result-details-icon result-details-icon-pass">
-              <span class="oi oi-check" title="Pass" aria-hidden="true"></span>
+            <div class="result-details-icon result-details-icon-pass" data-toggle="tooltip" title="Test passed.">
+              <span class="oi oi-check"></span>
             </div>
         <% when 'fail' %>
-            <div class="result-details-icon result-details-icon-fail">
-              <span class="oi oi-x" title="Fail" aria-hidden="true"></span>
-            </div>
+            <% if result.required %>
+                <div class="result-details-icon result-details-icon-fail" data-toggle="tooltip" title="Test Failed.  Click for more information.">
+                  <span class="oi oi-x"></span>
+                </div>
+            <% else %>
+                <div class="result-details-icon result-details-icon-fail-optional" data-toggle="tooltip" title="Optional test failed. Optional tests are not required for conformance.">
+                  <span class="oi oi-x"></span>
+                </div>
+            <% end %>
         <% when 'cancel' %>
-            <div class="result-details-icon result-details-icon-cancel">
+            <div class="result-details-icon result-details-icon-cancel" data-toggle="tooltip" title="Test cancelled by user during execution.">
               <span class="oi oi-x" title="Cancel" aria-hidden="true"></span>
             </div>
         <% when 'error' %>
-            <div class="result-details-icon result-details-icon-error">
+            <div class="result-details-icon result-details-icon-error" data-toggle="tooltip" title="Fatal error occurred during test.">
               !
             </div>
         <% when 'skip' %>
-            <div class="result-details-icon result-details-icon-skip">
+            <div class="result-details-icon result-details-icon-skip" data-toggle="tooltip" title="Test was skipped and does not affect passing or failed scores.  Click for more information.">
               <span class="oi oi-ban" title="Skip" aria-hidden="true"></span>
             </div>
         <% when 'wait' %>
-            <div class="result-details-icon result-details-icon-wait">
-              <span class="oi oi-media-pause" title="waiting" aria-hidden="true"></span>
+            <div class="result-details-icon result-details-icon-wait" data-toggle="tooltip" title="Test is waiting for a server launch or redirect">
+              <span class="oi oi-media-pause"></span>
             </div>
         <% when 'todo' %>
             <div class="result-details-icon result-details-icon-todo">
-              <span class="oi oi-minus" title="todo" aria-hidden="true"></span>
+              <span class="oi oi-minus"></span>
             </div>
         <% end %>
         <% if result.test_warnings.length > 0 %>
-            <div class="result-details-icon result-details-icon-warning">
-              <span class="oi oi-warning" title="todo" aria-hidden="true"></span>
+            <div class="result-details-icon result-details-icon-warning" data-toggle="tooltip" title="<%= result.test_warnings.length %> warning(s).  Warnings do not result in a test failure.">
+              <span class="oi oi-warning" data-toggle="tooltip" title="Test is waiting for a server launch or redirect"></span>
             </div>
+        <% else %>
+            <div class="result-details-icon result-details-icon-warning"></div>
         <% end %>
 
         <% unless result.request_responses.find{ |f| f.direction == 'outbound'}.nil? %>
-            <div class="result-details-icon result-details-icon-requests">
-              <span class="oi oi-arrow-thick-right" title="outbound requests" aria-hidden="true"></span>
+            <div class="result-details-icon result-details-icon-requests" data-toggle="tooltip" title="Test contains outbound http requests.  Click to view.">
+              <span class="oi oi-arrow-thick-right"></span>
             </div>
+        <% else %>
+            <div class="result-details-icon result-details-icon-requests"></div>
         <% end %>
 
         <% unless result.request_responses.find{ |f| f.direction == 'inbound'}.nil? %>
-            <div class="result-details-icon result-details-icon-requests">
-              <span class="oi oi-arrow-thick-left" title="inbound requests" aria-hidden="true"></span>
+            <div class="result-details-icon result-details-icon-requests" data-toggle="tooltip" title="Test contains inbound http requests.  Click to view.">
+              <span class="oi oi-arrow-thick-left"></span>
             </div>
+        <% else %>
+            <div class="result-details-icon result-details-icon-requests"></div>
         <% end %>
 
         <% if result.result == 'todo' %> TODO: <% end %>
+        <% unless result.required %> [ OPTIONAL ] <% end %>
         <%= result.name %>
-        <% unless result.required %> (optional) <% end %>
         <% unless result.message.nil? %>
           <div class="result-details-message">
-            Details: <%= result.message %>
+              Details: <%= result.message %>  
+              <% unless result.required %> <br/>This optional test is not required for conformance. <% end %>
           </div>
         <% end %>
       </li>

--- a/views/test_result_details.erb
+++ b/views/test_result_details.erb
@@ -28,8 +28,8 @@
           <span class="oi oi-warning" title="Skip" aria-hidden="true"></span>
         </div>
       <% end %>
+      <% unless @test_result.required %> [OPTIONAL] <% end %>
       <%= @test_result.name %>
-      <% unless @test_result.required %> (optional) <% end %>
     </div>
 
     <% unless @test_result.description.nil? %>


### PR DESCRIPTION
Optional tests that fail still show up as failing, but the error sign is muted and it doesn't roll up to the sequence level as a fail.  The previous mode of  it showing as pass + warning made no sense, because it wasn't passing.  Also fine tuned some UI elements (moved warning sign & request/response sign to right, added more hint tooltips)