### PR TITLE
Added in tests for introspection of the refresh client.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -262,6 +262,7 @@ namespace BASE_PATH do
 
     # copy over the access token to a different place in case it's not the same
     @instance.update(introspect_token: params['access_token'])
+    @instance.update(introspect_refresh_token: params['refresh_token'])
 
     redirect "/#{BASE_PATH}/#{params[:id]}/TokenIntrospection/"
 

--- a/lib/sequences/06_token_introspection_sequence.rb
+++ b/lib/sequences/06_token_introspection_sequence.rb
@@ -24,7 +24,7 @@ class TokenIntrospectionSequence < SequenceBase
   end
 
 
-  test 'Token introspection endpoint responds properly to introspection request',
+  test 'Token introspection endpoint responds properly to introspection request for access token',
           'https://tools.ietf.org/html/rfc7662',
           'A resource server is capable of calling the introspection endpoint.' do
 
@@ -57,12 +57,12 @@ class TokenIntrospectionSequence < SequenceBase
 
     active = @introspection_response_body['active']
 
-    assert active, 'Token is not active, try the test again with a valid token'
+    assert active, 'Token is not active, try the test again with a valid Access token'
   end
 
   test 'Scopes returned by token introspection request match expected scopes',
           'https://tools.ietf.org/html/rfc7662',
-          'The scopes we received alongside the token match those from the introspection response.',
+          'The scopes we received alongside the Access token match those from the introspection response.',
           :optional do
 
     assert !@introspection_response_body.nil?, 'No introspection response body'
@@ -82,9 +82,9 @@ class TokenIntrospectionSequence < SequenceBase
   end
 
   # TODO verify timeout requirements
-  test 'Token introspection response confirms token has appropriate lifetime',
+  test 'Token introspection response confirms Access token has appropriate lifetime',
           'https://tools.ietf.org/html/rfc7662',
-          'The token should have a lifetime of at least 60 minutes.' do
+          'The Access token should have a lifetime of at least 60 minutes.' do
 
     assert !@introspection_response_body.nil?, 'No introspection response body'
 
@@ -96,13 +96,13 @@ class TokenIntrospectionSequence < SequenceBase
     max_token_seconds = 60 * 60 # one hour expiration?
     clock_slip = 5 # a few seconds of clock skew allowed
 
-    assert (expiration - token_retrieved_at) < max_token_seconds, "Token does not have adequate lifetime of at least #{max_token_seconds} seconds"
+    assert (expiration - token_retrieved_at) < max_token_seconds, "Access token does not have adequate lifetime of at least #{max_token_seconds} seconds"
 
-    assert (now + Rational(clock_slip, (24 * 60 * 60))) < expiration, "Token has expired"
+    assert (now + Rational(clock_slip, (24 * 60 * 60))) < expiration, "Access token has expired"
 
   end
 
-  test 'Refresh Token - Token introspection endpoint responds properly to introspection request',
+  test 'Token introspection endpoint responds properly to introspection request for refresh token',
        'https://tools.ietf.org/html/rfc7662',
        'A resource server is capable of calling the introspection endpoint.',
        :optional do
@@ -130,7 +130,7 @@ class TokenIntrospectionSequence < SequenceBase
 
   end
 
-  test 'REFRESH - Token introspection response confirms that Access token is active',
+  test 'Token introspection response confirms that Refresh token is active',
        'https://tools.ietf.org/html/rfc7662',
        'A current access token is listed as active.',
        :optional do

--- a/models/testing_instance.rb
+++ b/models/testing_instance.rb
@@ -30,6 +30,7 @@ class TestingInstance
   property :resource_id, String
   property :resource_secret, String
   property :introspect_token, String
+  property :introspect_refresh_token, String
 
   has n, :sequence_results
   has n, :supported_resources, order: [:index.asc]

--- a/test/sequence/token_introspection_test.rb
+++ b/test/sequence/token_introspection_test.rb
@@ -177,8 +177,9 @@ class TokenIntrospectionSequenceTest < MiniTest::Unit::TestCase
 
     failures = sequence_result.test_results.select{|r| r.result != 'pass' && r.result != 'skip'}
 
-    # 1 test depends on active being true
-    assert failures.length == 1, 'One test should fail.'
+    # 1 optional test depends on active being true
+    assert failures.length == 1 && !failures.first.required, 'One optional test should fail.'
+    # This should still pass because the one failing test is optional
     assert sequence_result.result == 'pass', 'Sequence should pass.'
   end
 

--- a/views/details.erb
+++ b/views/details.erb
@@ -389,6 +389,10 @@
             <input type="text" class="form-control" name="access_token" id="access_token" value="<%= instance.token %>" required>
           </div>
           <div class="form-group">
+            <label for="access_token">Refresh Token</label>
+            <input type="text" class="form-control" name="refresh_token" id="refresh_token" value="<%= instance.refresh_token %>">
+          </div>
+          <div class="form-group">
             <label for="oauth_introspection_endpoint">Introspection URL</label>
             <input type="text" class="form-control" name="oauth_introspection_endpoint" id="oauth_introspection_endpoint" value="<%= instance.oauth_introspection_endpoint %>" required>
           </div>
@@ -481,7 +485,7 @@
               <div class="form-group row">
                 <label class="col-sm-3 col-form-label"><%=resource_type %></label>
                 <div class="col-sm-9">
-                  <texatarea class="form-control" rows=3 readonly><%=instance.resource_references.select{|r| r.resource_type == resource_type}.map(&:resource_id).join(', ') %></textarea>
+                  <textarea class="form-control" rows=3 readonly><%=instance.resource_references.select{|r| r.resource_type == resource_type}.map(&:resource_id).join(', ') %></textarea>
                 </div>
               </div>
             <% end %>


### PR DESCRIPTION
Added in additonal field in the TokenIntrospection Modal for refresh token.
Fixed typo in views/details.erb in the ArgonautProfilesModal (<texatarea> opening tag)